### PR TITLE
enhancement: (#2934) Allows flatten attribute to work for Optional values when deriving FromRow

### DIFF
--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -108,8 +108,6 @@ fn expand_derive_from_row_struct(
                 }
                 // Flatten
                 (true, None, false) => {
-                    predicates.push(parse_quote!(#ty: ::sqlx::FromRow<#lifetime, R>));
-                    //parse_quote!(<#ty as ::sqlx::FromRow<#lifetime, R>>::from_row(__row))
                     parse_quote!(::sqlx::__from_opt_row!(#ty, __row))
                 }
                 // Flatten + Try from

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -109,7 +109,8 @@ fn expand_derive_from_row_struct(
                 // Flatten
                 (true, None, false) => {
                     predicates.push(parse_quote!(#ty: ::sqlx::FromRow<#lifetime, R>));
-                    parse_quote!(<#ty as ::sqlx::FromRow<#lifetime, R>>::from_row(__row))
+                    //parse_quote!(<#ty as ::sqlx::FromRow<#lifetime, R>>::from_row(__row))
+                    parse_quote!(::sqlx::__from_opt_row!(#ty, __row))
                 }
                 // Flatten + Try from
                 (true, Some(try_from), false) => {

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -112,9 +112,8 @@ fn expand_derive_from_row_struct(
                 }
                 // Flatten + Try from
                 (true, Some(try_from), false) => {
-                    predicates.push(parse_quote!(#try_from: ::sqlx::FromRow<#lifetime, R>));
                     parse_quote!(
-                        <#try_from as ::sqlx::FromRow<#lifetime, R>>::from_row(__row)
+                        ::sqlx::__from_opt_row!(#try_from, __row)
                             .and_then(|v| {
                                 <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v)
                                     .map_err(|e| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@ pub use sqlx_core::connection::{ConnectOptions, Connection};
 pub use sqlx_core::database::{self, Database};
 pub use sqlx_core::describe::Describe;
 pub use sqlx_core::executor::{Execute, Executor};
-pub use sqlx_core::from_row::FromRow;
+pub use sqlx_core::from_row::{FromRow, Wrapper, FromOptRow};
+pub use sqlx_core::__from_opt_row;
 pub use sqlx_core::pool::{self, Pool};
 #[doc(hidden)]
 pub use sqlx_core::query::query_with_result as __query_with_result;


### PR DESCRIPTION
fixes #2934 