### PR TITLE
feat: Allow users to specify a prebuilt 'rustls' configuration for TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,6 +3946,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",

--- a/sqlx-core/src/net/tls/mod.rs
+++ b/sqlx-core/src/net/tls/mod.rs
@@ -57,13 +57,25 @@ impl std::fmt::Display for CertificateInput {
     }
 }
 
-pub struct TlsConfig<'a> {
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum TlsConfig<'a> {
+    RawTlsConfig(RawTlsConfig<'a>),
+    #[cfg(feature = "_tls-rustls")]
+    PrebuiltRustls {
+        config: &'a rustls::ClientConfig,
+        hostname: &'a str,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct RawTlsConfig<'a> {
     pub accept_invalid_certs: bool,
     pub accept_invalid_hostnames: bool,
     pub hostname: &'a str,
-    pub root_cert_path: Option<&'a CertificateInput>,
-    pub client_cert_path: Option<&'a CertificateInput>,
-    pub client_key_path: Option<&'a CertificateInput>,
+    pub root_cert: Option<&'a CertificateInput>,
+    pub client_cert: Option<&'a CertificateInput>,
+    pub client_key: Option<&'a CertificateInput>,
 }
 
 pub async fn handshake<S, Ws>(

--- a/sqlx-core/src/net/tls/tls_native_tls.rs
+++ b/sqlx-core/src/net/tls/tls_native_tls.rs
@@ -2,6 +2,7 @@ use std::io::{self, Read, Write};
 
 use crate::io::ReadBuf;
 use crate::net::tls::util::StdSocket;
+use crate::net::tls::RawTlsConfig;
 use crate::net::tls::TlsConfig;
 use crate::net::Socket;
 use crate::rt;
@@ -39,36 +40,56 @@ impl<S: Socket> Socket for NativeTlsSocket<S> {
     }
 }
 
+impl TlsConfig<'_> {
+    async fn native_tls_connector(&self) -> crate::Result<(native_tls::TlsConnector, &str), Error> {
+        #[allow(irrefutable_let_patterns)]
+        let TlsConfig::RawTlsConfig(RawTlsConfig {
+            root_cert,
+            client_cert,
+            client_key,
+            accept_invalid_certs,
+            accept_invalid_hostnames,
+            hostname,
+        }) = self
+        else {
+            unreachable!()
+        };
+        let mut builder = native_tls::TlsConnector::builder();
+
+        builder
+            .danger_accept_invalid_certs(*accept_invalid_certs)
+            .danger_accept_invalid_hostnames(*accept_invalid_hostnames);
+
+        if let Some(root_cert) = root_cert {
+            let data = root_cert.data().await?;
+            builder.add_root_certificate(
+                native_tls::Certificate::from_pem(&data).map_err(Error::tls)?,
+            );
+        }
+
+        // authentication using user's key-file and its associated certificate
+        if let (Some(cert), Some(key)) = (client_cert, client_key) {
+            let cert = cert.data().await?;
+            let key = key.data().await?;
+            let identity = Identity::from_pkcs8(&cert, &key).map_err(Error::tls)?;
+            builder.identity(identity);
+        }
+
+        // The openssl TlsConnector synchronously loads certificates from files.
+        // Loading these files can block for tens of milliseconds.
+        let connector = rt::spawn_blocking(move || builder.build())
+            .await
+            .map_err(Error::tls)?;
+        Ok((connector, hostname))
+    }
+}
+
 pub async fn handshake<S: Socket>(
     socket: S,
     config: TlsConfig<'_>,
 ) -> crate::Result<NativeTlsSocket<S>> {
-    let mut builder = native_tls::TlsConnector::builder();
-
-    builder
-        .danger_accept_invalid_certs(config.accept_invalid_certs)
-        .danger_accept_invalid_hostnames(config.accept_invalid_hostnames);
-
-    if let Some(root_cert_path) = config.root_cert_path {
-        let data = root_cert_path.data().await?;
-        builder.add_root_certificate(native_tls::Certificate::from_pem(&data).map_err(Error::tls)?);
-    }
-
-    // authentication using user's key-file and its associated certificate
-    if let (Some(cert_path), Some(key_path)) = (config.client_cert_path, config.client_key_path) {
-        let cert_path = cert_path.data().await?;
-        let key_path = key_path.data().await?;
-        let identity = Identity::from_pkcs8(&cert_path, &key_path).map_err(Error::tls)?;
-        builder.identity(identity);
-    }
-
-    // The openssl TlsConnector synchronously loads certificates from files.
-    // Loading these files can block for tens of milliseconds.
-    let connector = rt::spawn_blocking(move || builder.build())
-        .await
-        .map_err(Error::tls)?;
-
-    let mut mid_handshake = match connector.connect(config.hostname, StdSocket::new(socket)) {
+    let (connector, hostname) = config.native_tls_connector().await?;
+    let mut mid_handshake = match connector.connect(hostname, StdSocket::new(socket)) {
         Ok(tls_stream) => return Ok(NativeTlsSocket { stream: tls_stream }),
         Err(HandshakeError::Failure(e)) => return Err(Error::tls(e)),
         Err(HandshakeError::WouldBlock(mid_handshake)) => mid_handshake,

--- a/sqlx-mysql/src/connection/tls.rs
+++ b/sqlx-mysql/src/connection/tls.rs
@@ -1,3 +1,5 @@
+use sqlx_core::net::tls::RawTlsConfig;
+
 use crate::connection::{MySqlStream, Waiting};
 use crate::error::Error;
 use crate::net::tls::TlsConfig;
@@ -53,17 +55,17 @@ pub(super) async fn maybe_upgrade<S: Socket>(
         }
     }
 
-    let tls_config = TlsConfig {
+    let tls_config = TlsConfig::RawTlsConfig(RawTlsConfig {
         accept_invalid_certs: !matches!(
             options.ssl_mode,
             MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity
         ),
         accept_invalid_hostnames: !matches!(options.ssl_mode, MySqlSslMode::VerifyIdentity),
         hostname: &options.host,
-        root_cert_path: options.ssl_ca.as_ref(),
-        client_cert_path: options.ssl_client_cert.as_ref(),
-        client_key_path: options.ssl_client_key.as_ref(),
-    };
+        root_cert: options.ssl_ca.as_ref(),
+        client_cert: options.ssl_client_cert.as_ref(),
+        client_key: options.ssl_client_key.as_ref(),
+    });
 
     // Request TLS upgrade
     stream.write_packet(SslRequest {

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -14,6 +14,7 @@ any = ["sqlx-core/any"]
 json = ["sqlx-core/json"]
 migrate = ["sqlx-core/migrate"]
 offline = ["sqlx-core/offline"]
+rustls = ["dep:rustls", "sqlx-core/_tls-rustls"]
 
 # Type Integration features
 bigdecimal = ["dep:bigdecimal", "dep:num-bigint", "sqlx-core/bigdecimal"]
@@ -27,6 +28,9 @@ time = ["dep:time", "sqlx-core/time"]
 uuid = ["dep:uuid", "sqlx-core/uuid"]
 
 [dependencies]
+# TLS
+rustls = { version = "0.23.24", default-features = false, features = ["std", "tls12"], optional = true }
+
 # Futures crates
 futures-channel = { version = "0.3.19", default-features = false, features = ["sink", "alloc", "std"] }
 futures-core = { version = "0.3.19", default-features = false }

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -22,14 +22,26 @@ pub struct PgConnectOptions {
     pub(crate) password: Option<String>,
     pub(crate) database: Option<String>,
     pub(crate) ssl_mode: PgSslMode,
-    pub(crate) ssl_root_cert: Option<CertificateInput>,
-    pub(crate) ssl_client_cert: Option<CertificateInput>,
-    pub(crate) ssl_client_key: Option<CertificateInput>,
+    pub(crate) ssl_config: SslConfig,
     pub(crate) statement_cache_capacity: usize,
     pub(crate) application_name: Option<String>,
     pub(crate) log_settings: LogSettings,
     pub(crate) extra_float_digits: Option<Cow<'static, str>>,
     pub(crate) options: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SslConfig {
+    Libpq(LibpqSslConfig),
+    #[cfg(feature = "rustls")]
+    Rustls(rustls::ClientConfig),
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LibpqSslConfig {
+    pub(crate) root_cert: Option<CertificateInput>,
+    pub(crate) client_cert: Option<CertificateInput>,
+    pub(crate) client_key: Option<CertificateInput>,
 }
 
 impl Default for PgConnectOptions {
@@ -68,6 +80,15 @@ impl PgConnectOptions {
 
         let database = var("PGDATABASE").ok();
 
+        let ssl_config = SslConfig::Libpq(LibpqSslConfig {
+            root_cert: var("PGSSLROOTCERT").ok().map(CertificateInput::from),
+            client_cert: var("PGSSLCERT").ok().map(CertificateInput::from),
+            // As of writing, the implementation of `From<String>` only looks for
+            // `-----BEGIN CERTIFICATE-----` and so will not attempt to parse
+            // a PEM-encoded private key.
+            client_key: var("PGSSLKEY").ok().map(CertificateInput::from),
+        });
+
         PgConnectOptions {
             port,
             host,
@@ -75,12 +96,7 @@ impl PgConnectOptions {
             username,
             password: var("PGPASSWORD").ok(),
             database,
-            ssl_root_cert: var("PGSSLROOTCERT").ok().map(CertificateInput::from),
-            ssl_client_cert: var("PGSSLCERT").ok().map(CertificateInput::from),
-            // As of writing, the implementation of `From<String>` only looks for
-            // `-----BEGIN CERTIFICATE-----` and so will not attempt to parse
-            // a PEM-encoded private key.
-            ssl_client_key: var("PGSSLKEY").ok().map(CertificateInput::from),
+            ssl_config,
             ssl_mode: var("PGSSLMODE")
                 .ok()
                 .and_then(|v| v.parse().ok())
@@ -232,7 +248,16 @@ impl PgConnectOptions {
     ///     .ssl_root_cert("./ca-certificate.crt");
     /// ```
     pub fn ssl_root_cert(mut self, cert: impl AsRef<Path>) -> Self {
-        self.ssl_root_cert = Some(CertificateInput::File(cert.as_ref().to_path_buf()));
+        let cert = Some(CertificateInput::File(cert.as_ref().to_path_buf()));
+        #[allow(irrefutable_let_patterns)]
+        if let SslConfig::Libpq(c) = &mut self.ssl_config {
+            c.root_cert = cert;
+        } else {
+            self.ssl_config = SslConfig::Libpq(LibpqSslConfig {
+                root_cert: cert,
+                ..Default::default()
+            });
+        }
         self
     }
 
@@ -248,7 +273,16 @@ impl PgConnectOptions {
     ///     .ssl_client_cert("./client.crt");
     /// ```
     pub fn ssl_client_cert(mut self, cert: impl AsRef<Path>) -> Self {
-        self.ssl_client_cert = Some(CertificateInput::File(cert.as_ref().to_path_buf()));
+        let cert = Some(CertificateInput::File(cert.as_ref().to_path_buf()));
+        #[allow(irrefutable_let_patterns)]
+        if let SslConfig::Libpq(c) = &mut self.ssl_config {
+            c.client_cert = cert;
+        } else {
+            self.ssl_config = SslConfig::Libpq(LibpqSslConfig {
+                client_cert: cert,
+                ..Default::default()
+            });
+        }
         self
     }
 
@@ -267,14 +301,23 @@ impl PgConnectOptions {
     /// -----BEGIN CERTIFICATE-----
     /// <Certificate data here.>
     /// -----END CERTIFICATE-----";
-    ///    
+    ///
     /// let options = PgConnectOptions::new()
     ///     // Providing a CA certificate with less than VerifyCa is pointless
     ///     .ssl_mode(PgSslMode::VerifyCa)
     ///     .ssl_client_cert_from_pem(CERT);
     /// ```
     pub fn ssl_client_cert_from_pem(mut self, cert: impl AsRef<[u8]>) -> Self {
-        self.ssl_client_cert = Some(CertificateInput::Inline(cert.as_ref().to_vec()));
+        let cert = Some(CertificateInput::Inline(cert.as_ref().to_vec()));
+        #[allow(irrefutable_let_patterns)]
+        if let SslConfig::Libpq(c) = &mut self.ssl_config {
+            c.client_cert = cert;
+        } else {
+            self.ssl_config = SslConfig::Libpq(LibpqSslConfig {
+                client_cert: cert,
+                ..Default::default()
+            });
+        }
         self
     }
 
@@ -290,7 +333,16 @@ impl PgConnectOptions {
     ///     .ssl_client_key("./client.key");
     /// ```
     pub fn ssl_client_key(mut self, key: impl AsRef<Path>) -> Self {
-        self.ssl_client_key = Some(CertificateInput::File(key.as_ref().to_path_buf()));
+        let key = Some(CertificateInput::File(key.as_ref().to_path_buf()));
+        #[allow(irrefutable_let_patterns)]
+        if let SslConfig::Libpq(c) = &mut self.ssl_config {
+            c.client_key = key;
+        } else {
+            self.ssl_config = SslConfig::Libpq(LibpqSslConfig {
+                client_key: key,
+                ..Default::default()
+            });
+        }
         self
     }
 
@@ -316,7 +368,16 @@ impl PgConnectOptions {
     ///     .ssl_client_key_from_pem(KEY);
     /// ```
     pub fn ssl_client_key_from_pem(mut self, key: impl AsRef<[u8]>) -> Self {
-        self.ssl_client_key = Some(CertificateInput::Inline(key.as_ref().to_vec()));
+        let key = Some(CertificateInput::Inline(key.as_ref().to_vec()));
+        #[allow(irrefutable_let_patterns)]
+        if let SslConfig::Libpq(c) = &mut self.ssl_config {
+            c.client_key = key;
+        } else {
+            self.ssl_config = SslConfig::Libpq(LibpqSslConfig {
+                client_key: key,
+                ..Default::default()
+            });
+        }
         self
     }
 
@@ -332,7 +393,16 @@ impl PgConnectOptions {
     ///     .ssl_root_cert_from_pem(vec![]);
     /// ```
     pub fn ssl_root_cert_from_pem(mut self, pem_certificate: Vec<u8>) -> Self {
-        self.ssl_root_cert = Some(CertificateInput::Inline(pem_certificate));
+        let cert = Some(CertificateInput::Inline(pem_certificate));
+        #[allow(irrefutable_let_patterns)]
+        if let SslConfig::Libpq(c) = &mut self.ssl_config {
+            c.root_cert = cert;
+        } else {
+            self.ssl_config = SslConfig::Libpq(LibpqSslConfig {
+                root_cert: cert,
+                ..Default::default()
+            });
+        }
         self
     }
 


### PR DESCRIPTION
### Does your PR solve an issue?

Closes #4049.

### Is this a breaking change?

No.
There is a breaking change for `sqlx-core`, but that's considered [semver-exempt](https://docs.rs/sqlx-core/0.8.6/sqlx_core/#note-semver-exempt-api).

## Open Design questions

### What should the interaction be between `sslmode` and a prebuilt `rustls` configuration?

In the current PR, if TLS is available, we behave as if the user specified `PgSslMode::VerifyFull`.
[`rustls::client::ClientConfig`](https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html) doesn't expose the underlying server cert verifier, therefore it's not possible to wrap around it to disable hostname verification or cert verification.
At the same time, I think it'd be surprising for a user that specified its own `rustls` configuration to get the kind of permissive behaviour that `PgSslMode::Prefer` implies.

### Conversion into a URL is inevitably lossy

We can't convert a prebuilt `rustls` client configuration into the three URL parameters that `libpq` supports.
At the moment, the PR ends up building a URL that doesn't have `ssl*` parameters. Would it be preferable to fail the conversion entirely?

## Follow-up work

If we agree on the approach, I can add prebuilt `rustls` support to MySQL; either in this PR or in a separate one.