### PR TITLE
fix: SQLite `AnyQueryResult::last_insert_id()` always returns `None`

### DIFF
--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -235,8 +235,5 @@ fn map_arguments(args: AnyArguments) -> SqliteArguments {
 }
 
 fn map_result(res: SqliteQueryResult) -> AnyQueryResult {
-    AnyQueryResult {
-        rows_affected: res.rows_affected(),
-        last_insert_id: None,
-    }
+    AnyQueryResult::from(res)
 }

--- a/tests/sqlite/any.rs
+++ b/tests/sqlite/any.rs
@@ -1,6 +1,45 @@
 use sqlx::Any;
 use sqlx_test::new;
 
+// Regression test for https://github.com/launchbadge/sqlx/issues/2982
+// `map_result()` in sqlx-sqlite/src/any.rs was discarding `last_insert_rowid`,
+// always returning `last_insert_id: None` in `AnyQueryResult`.
+#[sqlx_macros::test]
+async fn any_query_result_has_last_insert_id() -> anyhow::Result<()> {
+    sqlx::any::install_default_drivers();
+    let mut conn = new::<Any>().await?;
+
+    sqlx::query(
+        "CREATE TEMPORARY TABLE any_last_id_test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await?;
+
+    let result = sqlx::query("INSERT INTO any_last_id_test (name) VALUES (?)")
+        .bind("Alice")
+        .execute(&mut conn)
+        .await?;
+
+    assert_eq!(
+        result.last_insert_id(),
+        Some(1),
+        "first insert should return id 1"
+    );
+
+    let result = sqlx::query("INSERT INTO any_last_id_test (name) VALUES (?)")
+        .bind("Bob")
+        .execute(&mut conn)
+        .await?;
+
+    assert_eq!(
+        result.last_insert_id(),
+        Some(2),
+        "second insert should return id 2"
+    );
+
+    Ok(())
+}
+
 #[sqlx_macros::test]
 async fn it_encodes_bool_with_any() -> anyhow::Result<()> {
     sqlx::any::install_default_drivers();


### PR DESCRIPTION
## Summary

`AnyQueryResult::last_insert_id()` always returns `None` when using the SQLite backend through the `Any` driver, even after a successful `INSERT` into a table with `INTEGER PRIMARY KEY AUTOINCREMENT`.

### Root Cause

The `map_result()` function in `sqlx-sqlite/src/any.rs` hardcodes `last_insert_id: None`:

```rust
fn map_result(res: SqliteQueryResult) -> AnyQueryResult {
    AnyQueryResult {
        rows_affected: res.rows_affected(),
        last_insert_id: None, // <-- always None
    }
}
```

This is the function called by `AnyConnectionBackend::fetch_many()` for every query result.

Note that #3608 added a correct `From<SqliteQueryResult> for AnyQueryResult` implementation in `query_result.rs`, but the `fetch_many` code path still calls `map_result()` rather than using `From`, so that fix never takes effect.

### Fix

Replace the manual construction in `map_result()` with a delegation to the existing `From` impl:

```rust
fn map_result(res: SqliteQueryResult) -> AnyQueryResult {
    AnyQueryResult::from(res)
}
```

### Reproduction

```rust
sqlx::any::install_default_drivers();

let pool = AnyPool::connect("sqlite::memory:").await?;

sqlx::query("CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)")
    .execute(&pool)
    .await?;

let result = sqlx::query("INSERT INTO test (name) VALUES (?)")
    .bind("Alice")
    .execute(&pool)
    .await?;

// Before fix: None
// After fix:  Some(1)
println!("{:?}", result.last_insert_id());
```

### Test Plan

- Added regression test `any_query_result_has_last_insert_id` in `tests/sqlite/any.rs`
- Test creates a temporary table, inserts two rows, and asserts that `last_insert_id()` returns `Some(1)` and `Some(2)` respectively

Closes #2982