### PR TITLE
fix(cli): replace dialoguer drop prompt with line-based read for accessibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,17 +1189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
-dependencies = [
- "console",
- "shell-words",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3375,12 +3364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,7 +3518,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "console",
- "dialoguer",
  "dotenvy",
  "filetime",
  "futures-util",

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -34,7 +34,6 @@ clap_complete = { version = "4.3.1", optional = true }
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 anyhow = "1.0.52"
 console = "0.15.0"
-dialoguer = { version = "0.11", default-features = false }
 serde_json = "1.0.73"
 glob = "0.3.0"
 openssl = { version = "0.10.46", optional = true }

--- a/sqlx-cli/src/database.rs
+++ b/sqlx-cli/src/database.rs
@@ -1,10 +1,9 @@
 use crate::opt::{ConnectOpts, MigrationSourceOpt};
 use crate::{migrate, Config};
-use console::{style, Term};
-use dialoguer::Confirm;
+use console::style;
 use sqlx::any::Any;
 use sqlx::migrate::MigrateDatabase;
-use std::{io, mem};
+use std::io::{self, BufRead, Write};
 use tokio::task;
 
 pub async fn create(connect_opts: &ConnectOpts) -> anyhow::Result<()> {
@@ -66,45 +65,56 @@ pub async fn setup(
 }
 
 async fn ask_to_continue_drop(db_url: String) -> bool {
-    // If the setup operation is cancelled while we are waiting for the user to decide whether
-    // or not to drop the database, this will restore the terminal's cursor to its normal state.
-    struct RestoreCursorGuard {
-        disarmed: bool,
-    }
+    task::spawn_blocking(move || {
+        let stderr = io::stderr();
+        let mut stderr_lock = stderr.lock();
+        let _ = write!(
+            stderr_lock,
+            "Drop database at {}? (y/N): ",
+            style(&db_url).cyan()
+        );
+        let _ = stderr_lock.flush();
+        std::mem::drop(stderr_lock);
 
-    impl Drop for RestoreCursorGuard {
-        fn drop(&mut self) {
-            if !self.disarmed {
-                Term::stderr().show_cursor().unwrap()
-            }
+        let stdin = io::stdin();
+        let mut line = String::new();
+        match stdin.lock().read_line(&mut line) {
+            Ok(0) | Err(_) => false,
+            Ok(_) => parse_drop_response(&line),
         }
-    }
-
-    let mut guard = RestoreCursorGuard { disarmed: false };
-
-    let decision_result = task::spawn_blocking(move || {
-        Confirm::new()
-            .with_prompt(format!("Drop database at {}?", style(&db_url).cyan()))
-            .wait_for_newline(true)
-            .default(false)
-            .show_default(true)
-            .interact()
     })
     .await
-    .expect("Confirm thread panicked");
-    match decision_result {
-        Ok(decision) => {
-            guard.disarmed = true;
-            decision
+    .expect("Confirm thread panicked")
+}
+
+fn parse_drop_response(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.eq_ignore_ascii_case("y") || trimmed.eq_ignore_ascii_case("yes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_drop_response;
+
+    #[test]
+    fn parse_drop_response_accepts_yes() {
+        for input in ["y", "Y", "yes", "YES", "Yes", "y\n", "yes\r\n", " yes "] {
+            assert!(
+                parse_drop_response(input),
+                "expected yes for input {input:?}"
+            );
         }
-        Err(dialoguer::Error::IO(err)) if err.kind() == io::ErrorKind::Interrupted => {
-            // Sometimes CTRL + C causes this error to be returned
-            mem::drop(guard);
-            false
-        }
-        Err(err) => {
-            mem::drop(guard);
-            panic!("Confirm dialog failed with {err}")
+    }
+
+    #[test]
+    fn parse_drop_response_rejects_everything_else() {
+        for input in [
+            "", "\n", "\r\n", "n", "N", "no", "NO", "maybe", " ", "xyz", "yep",
+        ] {
+            assert!(
+                !parse_drop_response(input),
+                "expected no for input {input:?}"
+            );
         }
     }
 }

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -58,9 +58,9 @@ pub fn maybe_apply_dotenv() {
 
 pub async fn run(opt: Opt) -> anyhow::Result<()> {
     // This `select!` is here so that when the process receives a `SIGINT` (CTRL + C),
-    // the futures currently running on this task get dropped before the program exits.
-    // This is currently necessary for the consumers of the `dialoguer` crate to restore
-    // the user's terminal if the process is interrupted while a dialog is being displayed.
+    // the futures currently running on this task get dropped before the program exits,
+    // ensuring any in-progress operation (such as the interactive drop-database prompt)
+    // is cancelled cleanly rather than left running during shutdown.
 
     let ctrlc_fut = signal::ctrl_c();
     let do_run_fut = do_run(opt);


### PR DESCRIPTION
## Summary

Replaces the `dialoguer::Confirm` prompt in `sqlx database drop` with a plain `stdin().read_line` so that screen readers, large-print users, and anyone relying on terminal echo get predictable behaviour. Closes #4236.

## Why

As reported in #4236, the existing prompt uses `dialoguer::Confirm` with `wait_for_newline(true)`. In that mode dialoguer still puts the terminal into raw input for the `Y/N` toggle, which causes two separate failure modes:

- **Wrapped prompt (large print / narrow terminal):** each keypress redraws the whole prompt to flip `[Y/n]` ↔ `[y/N]`, and screen readers re-parse the full line each time.
- **Single-line prompt (wide terminal):** keypresses silently flip the default marker with no visual echo and no audible announcement — the user has no feedback that their input registered.

In both cases the pressed key is never displayed and there's no explicit "press Enter" cue.

## What changed

- `ask_to_continue_drop` now writes the prompt with an explicit `(y/N)` hint and reads a line from stdin.
- No raw mode → keypresses echo naturally, Enter is the only implicit terminator, and screen readers get a normal line-at-a-time interaction.
- The `RestoreCursorGuard` is gone because the cursor is never hidden.
- `--force` / `-y` / non-TTY behaviour is unchanged (only the interactive `confirm=true` path is touched).

A small pure `parse_drop_response` helper is introduced and unit-tested so the accept/reject matrix is exercised in CI.

## Before / After

**Before** (wrapped prompt, with a screen reader):
```
? Drop database at postgres://…? [Y/n]  ← full prompt re-read on every Y press
```

**After:**
```
Drop database at postgres://…? (y/N): y
```
Keypress echoes, Enter commits, screen readers announce just the single line.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --manifest-path sqlx-cli/Cargo.toml -- -D warnings`
- [x] `cargo test --manifest-path sqlx-cli/Cargo.toml` (3 unit + 8 add + 3 migrate tests pass)
- [x] Manual: `echo y | cargo run -- database drop -D sqlite://test.db` proceeds; `echo n` and empty input abort.