### PR TITLE
sqlx-cli: drop the literal style override that was invisible on light terminals

### DIFF
--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 const HELP_STYLES: Styles = Styles::styled()
     .header(AnsiColor::Blue.on_default().bold())
     .usage(AnsiColor::Blue.on_default().bold())
-    .literal(AnsiColor::White.on_default())
+    .literal(AnsiColor::Cyan.on_default())
     .placeholder(AnsiColor::Green.on_default());
 
 #[derive(Parser, Debug)]

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -16,7 +16,6 @@ use std::path::PathBuf;
 const HELP_STYLES: Styles = Styles::styled()
     .header(AnsiColor::Blue.on_default().bold())
     .usage(AnsiColor::Blue.on_default().bold())
-    .literal(AnsiColor::Cyan.on_default())
     .placeholder(AnsiColor::Green.on_default());
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
Fixes #4112.

`AnsiColor::White` is invisible on light/white terminal backgrounds. Dropping the explicit `.literal()` style lets it fall back to the terminal default, which is readable on both light and dark terminals.

(Initial version switched to Cyan; per maintainer feedback, default is fine.)