### PR TITLE
fix: resolve #4284 — Claude Code Review Report

### DIFF
--- a/sqlx-core/src/any/arguments.rs
+++ b/sqlx-core/src/any/arguments.rs
@@ -67,8 +67,8 @@ impl AnyArguments {
                 AnyValueKind::Null(AnyTypeInfoKind::SmallInt) => out.add(Option::<i16>::None),
                 AnyValueKind::Null(AnyTypeInfoKind::Integer) => out.add(Option::<i32>::None),
                 AnyValueKind::Null(AnyTypeInfoKind::BigInt) => out.add(Option::<i64>::None),
-                AnyValueKind::Null(AnyTypeInfoKind::Real) => out.add(Option::<f64>::None),
-                AnyValueKind::Null(AnyTypeInfoKind::Double) => out.add(Option::<f32>::None),
+                AnyValueKind::Null(AnyTypeInfoKind::Real) => out.add(Option::<f32>::None),
+                AnyValueKind::Null(AnyTypeInfoKind::Double) => out.add(Option::<f64>::None),
                 AnyValueKind::Null(AnyTypeInfoKind::Text) => out.add(Option::<String>::None),
                 AnyValueKind::Null(AnyTypeInfoKind::Blob) => out.add(Option::<Vec<u8>>::None),
                 AnyValueKind::Bool(b) => out.add(b),
@@ -83,5 +83,48 @@ impl AnyArguments {
             }?
         }
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convert_into_maps_null_real_to_f32_and_null_double_to_f64() {
+        let mut args = AnyArguments::default();
+        args.values.0.push(AnyValueKind::Null(AnyTypeInfoKind::Real));
+        args.values.0.push(AnyValueKind::Null(AnyTypeInfoKind::Double));
+
+        let out: AnyArguments = args.convert_into().unwrap();
+
+        assert_eq!(out.values.0.len(), 2);
+        assert!(matches!(
+            out.values.0[0],
+            AnyValueKind::Null(AnyTypeInfoKind::Real)
+        ));
+        assert!(matches!(
+            out.values.0[1],
+            AnyValueKind::Null(AnyTypeInfoKind::Double)
+        ));
+    }
+
+    #[test]
+    fn convert_into_preserves_non_float_null_types() {
+        let mut args = AnyArguments::default();
+        args.values.0.push(AnyValueKind::Null(AnyTypeInfoKind::Integer));
+        args.values.0.push(AnyValueKind::Null(AnyTypeInfoKind::BigInt));
+
+        let out: AnyArguments = args.convert_into().unwrap();
+
+        assert_eq!(out.values.0.len(), 2);
+        assert!(matches!(
+            out.values.0[0],
+            AnyValueKind::Null(AnyTypeInfoKind::Integer)
+        ));
+        assert!(matches!(
+            out.values.0[1],
+            AnyValueKind::Null(AnyTypeInfoKind::BigInt)
+        ));
     }
 }

--- a/sqlx-core/src/any/connection/mod.rs
+++ b/sqlx-core/src/any/connection/mod.rs
@@ -101,7 +101,7 @@ impl Connection for AnyConnection {
     }
 
     fn close_hard(self) -> impl Future<Output = Result<(), Error>> + Send + 'static {
-        self.backend.close()
+        self.backend.close_hard()
     }
 
     fn ping(&mut self) -> impl Future<Output = Result<(), Error>> + Send + '_ {

--- a/sqlx-macros-core/src/query/metadata.rs
+++ b/sqlx-macros-core/src/query/metadata.rs
@@ -156,7 +156,33 @@ fn load_env(
     }))
 }
 
-/// Returns `true` if `val` is `"true"`,
+/// Returns `true` if `val` is `"true"` (case-insensitive) or `"1"`.
 fn is_truthy_bool(val: &str) -> bool {
     val.eq_ignore_ascii_case("true") || val == "1"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_truthy_bool;
+
+    #[test]
+    fn truthy_values_return_true() {
+        assert!(is_truthy_bool("true"));
+        assert!(is_truthy_bool("1"));
+    }
+
+    #[test]
+    fn truthy_is_case_insensitive() {
+        assert!(is_truthy_bool("TRUE"));
+        assert!(is_truthy_bool("True"));
+        assert!(is_truthy_bool("tRuE"));
+    }
+
+    #[test]
+    fn falsy_values_return_false() {
+        assert!(!is_truthy_bool("false"));
+        assert!(!is_truthy_bool("0"));
+        assert!(!is_truthy_bool(""));
+        assert!(!is_truthy_bool("yes"));
+    }
 }

--- a/sqlx-sqlite/src/logger.rs
+++ b/sqlx-sqlite/src/logger.rs
@@ -59,6 +59,43 @@ fn dot_escape_string(value: impl AsRef<str>) -> String {
         .to_string()
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::intmap::IntMap;
+    use std::collections::HashSet;
+
+    #[derive(Debug)]
+    struct TestState;
+
+    impl DebugDiff for TestState {
+        fn diff(&self, _prev: &Self) -> String {
+            String::new()
+        }
+    }
+
+    #[test]
+    fn max_branch_id_includes_branch_origins() {
+        let program: &[&str] = &["Init"];
+        let mut logger: QueryPlanLogger<'_, i64, TestState, &str> = QueryPlanLogger {
+            sql: "SELECT 1",
+            unknown_operations: HashSet::new(),
+            branch_origins: IntMap::new(),
+            branch_results: IntMap::new(),
+            branch_operations: IntMap::new(),
+            program,
+        };
+
+        logger
+            .branch_origins
+            .insert(7, BranchParent { id: 0, idx: 0 });
+
+        let rendered = logger.to_string();
+
+        assert!(rendered.contains('7'));
+    }
+}
+
 impl<R: Debug, S: Debug + DebugDiff, P: Debug> core::fmt::Display for QueryPlanLogger<'_, R, S, P> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         //writes query plan history in dot format
@@ -224,7 +261,7 @@ impl<R: Debug, S: Debug + DebugDiff, P: Debug> core::fmt::Display for QueryPlanL
         let max_branch_id: i64 = [
             self.branch_operations.last_index().unwrap_or(0),
             self.branch_results.last_index().unwrap_or(0),
-            self.branch_results.last_index().unwrap_or(0),
+            self.branch_origins.last_index().unwrap_or(0),
         ]
         .into_iter()
         .max()


### PR DESCRIPTION
## Summary

Combined multi-file contribution:

## Changes

- `sqlx-core/src/any/arguments.rs`
- `sqlx-core/src/any/connection/mod.rs`
- `sqlx-sqlite/src/logger.rs`
- `sqlx-macros-core/src/query/metadata.rs`

## Why

`sqlx-core/src/any/arguments.rs`: In `AnyArguments::convert_into`, the NULL float type mappings are swapped. `AnyTypeInfoKind::Real` corresponds to `f32` but is encoded as `Option::<f64>::None`, and `AnyTypeInfoKind::Double` corresponds to `f64` but is encoded as `Option::<f32>::None`. Binding a NULL `f32`/`f64` through the `Any` driver sends the wrong SQL type hint, which can produce a type-mismatch error on strongly-typed backends like Postgres.
