### PR TITLE
fix: resolve #2642 — Query macro documentation understates lack of nullability checking on bind parameters

### DIFF
--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -93,6 +93,28 @@
 /// [configuration guide]: crate::_config::macros::Config
 /// [reference `sqlx.toml`]: crate::_config::_reference
 ///
+/// ## Nullability of Bind Parameters
+/// The `query!` family of macros checks the *types* of bind parameters against the
+/// database's inferred parameter types, but they do **not** check whether a bound
+/// value's nullability is compatible with the target column's `NOT NULL` constraint.
+///
+/// Databases generally report all bind parameters as nullable, and the macro has no
+/// way to associate a parameter with a specific column constraint at compile time.
+/// As a result, passing a `None`/`NULL` value for a non-nullable column compiles
+/// successfully and only fails at runtime with a database constraint violation:
+///
+/// ```rust,ignore
+/// // `name` is declared `NOT NULL`, but this still compiles;
+/// // it only fails at runtime when executed:
+/// let name: Option<String> = None;
+/// sqlx::query!("insert into accounts (name) values (?)", name)
+///     .execute(&mut conn)
+///     .await?;
+/// ```
+///
+/// Null-checking is only performed on the *output* columns of a query, not on the
+/// *input* bind parameters.
+///
 /// ## Query Arguments
 /// Like `println!()` and the other formatting macros, you can add bind parameters to your SQL
 /// and this macro will typecheck passed arguments and error on missing ones:


### PR DESCRIPTION
## Summary

The `query!` family of macros validates the *types* of bind parameters against the database's inferred parameter types, but it does not verify whether a bound value's nullability is compatible with the target column's NOT NULL constraint. As a result, passing a `None`/`NULL` value for a non-nullable column compiles successfully and only fails at runtime with a database constraint violation. This is a known limitation (databases generally report bind parameters as nullable, and the macro has no way to associate a parameter with a specific column constraint at compile time), but it is not currently documented, which surprised the user. We should add an explicit "Nullability" / "Limitations" note to the macro documentation explaining this behavior so users understand that null-checking is only performed on *output* columns, not on *input* bind parameters

Fixes #2642

## Changes

- `src/macros/mod.rs`

## Why

`src/macros/mod.rs`: The `query!` family of macros validates the *types* of bind parameters against the database's inferred parameter types, but it does not verify whether a bound value's nullability is compatible with the target column's NOT NULL constraint. As a result, passing a `None`/`NULL` value for a non-nullable column compiles successfully and only fails at runtime with a database constraint violation. This is a known limitation (databases generally report bind parameters as nullable, and the macro has no way to associate a parameter with a specific column constraint at compile time), but it is not currently documented, which surprised the user. We should add an explicit "Nullability" / "Limitations" note to the macro documentation explaining this behavior so users understand that null-checking is only performed on *output* columns, not on *input* bind parameters.
