### PR TITLE
feat: support DATABASE_URL_TEST env var override in #[sqlx::test]

### DIFF
--- a/sqlx-mysql/src/testing/mod.rs
+++ b/sqlx-mysql/src/testing/mod.rs
@@ -37,7 +37,9 @@ impl TestSupport for MySql {
     }
 
     async fn cleanup_test_dbs() -> Result<Option<usize>, Error> {
-        let url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
+        let url = dotenvy::var("DATABASE_URL_TEST")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
+        .expect("DATABASE_URL_TEST or DATABASE_URL must be set");
 
         let mut conn = MySqlConnection::connect(&url).await?;
 
@@ -97,7 +99,9 @@ impl TestSupport for MySql {
 }
 
 async fn test_context(args: &TestArgs) -> Result<TestContext<MySql>, Error> {
-    let url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let url = dotenvy::var("DATABASE_URL_TEST")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
+        .expect("DATABASE_URL_TEST or DATABASE_URL must be set");
 
     let master_opts = MySqlConnectOptions::from_str(&url).expect("failed to parse DATABASE_URL");
 

--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -39,7 +39,9 @@ impl TestSupport for Postgres {
     }
 
     async fn cleanup_test_dbs() -> Result<Option<usize>, Error> {
-        let url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
+        let url = dotenvy::var("DATABASE_URL_TEST")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
+        .expect("DATABASE_URL_TEST or DATABASE_URL must be set");
 
         let mut conn = PgConnection::connect(&url).await?;
 
@@ -90,7 +92,9 @@ impl TestSupport for Postgres {
 }
 
 async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
-    let url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let url = dotenvy::var("DATABASE_URL_TEST")
+        .or_else(|_| dotenvy::var("DATABASE_URL"))
+        .expect("DATABASE_URL_TEST or DATABASE_URL must be set");
 
     let master_opts = PgConnectOptions::from_str(&url).expect("failed to parse DATABASE_URL");
 


### PR DESCRIPTION
## Summary

Fixes #4302

## Changes

- **`sqlx-postgres/src/testing/mod.rs`**: Updated both `test_context` and `cleanup_test_dbs` to check `DATABASE_URL_TEST` first, falling back to `DATABASE_URL`
- **`sqlx-mysql/src/testing/mod.rs`**: Same change applied for MySQL testing

## Motivation

`#[sqlx::test]` requires a superuser connection to create/drop test databases. Many users want to keep their test credentials separate from development/production credentials following the principle of least privilege.

With this change, users can set `DATABASE_URL_TEST` to a superuser connection string for tests while keeping `DATABASE_URL` pointing to a restricted user for normal development.

## Behavior

- If `DATABASE_URL_TEST` is set, it is used for `#[sqlx::test]`
- If `DATABASE_URL_TEST` is not set, falls back to `DATABASE_URL` (existing behavior preserved — no breaking change)

## Testing

Existing behavior is unchanged when `DATABASE_URL_TEST` is not set. New behavior activates only when `DATABASE_URL_TEST` is explicitly provided.