### PR TITLE
feat(core, mysql): expose MySQL connection options to sqlx.toml

### DIFF
--- a/sqlx-core/src/config/drivers.rs
+++ b/sqlx-core/src/config/drivers.rs
@@ -40,14 +40,38 @@ pub struct Config {
 }
 
 /// Configuration for the MySQL database driver.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 #[cfg_attr(
     feature = "sqlx-toml",
     derive(serde::Deserialize),
     serde(default, rename_all = "kebab-case", deny_unknown_fields)
 )]
 pub struct MySqlConfig {
-    // No fields implemented yet. This key is only used to validate parsing.
+    /// Whether to enable the `PIPES_AS_CONCAT` connection setting
+    ///
+    /// Defaults to `true`.
+    ///
+    /// Some MySql databases such as PlanetScale error out with this connection setting
+    /// so it needs to be set `false` in such cases.
+    pub pipes_as_concat: bool,
+    /// Whether to enable the `NO_ENGINE_SUBSTITUTION` sql_mode setting after connection.
+    ///
+    /// Defaults to `true` (`NO_ENGINE_SUBSTITUTION` is passed, forbidding engine substitution.)
+    ///
+    /// If not set, if the available storage engine specified by a `CREATE TABLE` is not available,
+    /// a warning is given and the default storage engine is used instead.
+    ///
+    /// <https://mariadb.com/kb/en/sql-mode/>
+    pub no_engine_substitution: bool,
+}
+
+impl Default for MySqlConfig {
+    fn default() -> Self {
+        Self {
+            pipes_as_concat: true,
+            no_engine_substitution: true,
+        }
+    }
 }
 
 /// Configuration for the Postgres database driver.

--- a/sqlx-core/src/config/drivers.rs
+++ b/sqlx-core/src/config/drivers.rs
@@ -39,15 +39,57 @@ pub struct Config {
     pub external: ExternalDriverConfig,
 }
 
-/// Configuration for the MySQL database driver.
-#[derive(Debug, Default)]
+/// Configuration for the MySQL database driver (**applies to macros and `sqlx-cli` only**).
+///
+/// # Note: Does Not Apply at Application Run-Time
+/// As of writing, these configuration parameters do *not* have any bearing on
+/// the runtime configuration of the MySQL driver.
+///
+/// Any parameters which overlap with runtime configuration
+/// (e.g. [`drivers.mysql.pipes-as-concat`][MySqlConfig::pipes_as_concat])
+/// _must_ be configured their normal ways at runtime (e.g. `MySqlConnectOptions::pipes_as_concat()`).
+///
+/// See the documentation of individual fields for details.
+#[derive(Debug)]
 #[cfg_attr(
     feature = "sqlx-toml",
     derive(serde::Deserialize),
     serde(default, rename_all = "kebab-case", deny_unknown_fields)
 )]
 pub struct MySqlConfig {
-    // No fields implemented yet. This key is only used to validate parsing.
+    /// Whether to enable the `PIPES_AS_CONCAT` connection setting.
+    ///
+    /// Defaults to `true`.
+    ///
+    /// Some MySql databases such as PlanetScale error out with this connection setting
+    /// so it needs to be set `false` in such cases.
+    ///
+    /// # Note: Does Not Configure Runtime Connection Settings
+    /// The `PIPES_AS_CONCAT` setting at runtime *must* be separately configured with
+    /// `MySqlConnectOptions::pipes_as_concat()`.
+    pub pipes_as_concat: bool,
+    /// Whether to enable the `NO_ENGINE_SUBSTITUTION` sql_mode setting after connection.
+    ///
+    /// Defaults to `true` (`NO_ENGINE_SUBSTITUTION` is passed, forbidding engine substitution.)
+    ///
+    /// If not set, if the available storage engine specified by a `CREATE TABLE` is not available,
+    /// a warning is given and the default storage engine is used instead.
+    ///
+    /// <https://mariadb.com/kb/en/sql-mode/>
+    ///
+    /// # Note: Does Not Configure Runtime Connection Settings
+    /// The `NO_ENGINE_SUBSTITUTION` setting at runtime *must* be separately configured with
+    /// `MySqlConnectOptions::no_engine_substitution()`.
+    pub no_engine_substitution: bool,
+}
+
+impl Default for MySqlConfig {
+    fn default() -> Self {
+        Self {
+            pipes_as_concat: true,
+            no_engine_substitution: true,
+        }
+    }
 }
 
 /// Configuration for the Postgres database driver.

--- a/sqlx-core/src/config/reference.toml
+++ b/sqlx-core/src/config/reference.toml
@@ -22,7 +22,20 @@ database-url-var = "FOO_DATABASE_URL"
 
 # Configure MySQL databases in macros and sqlx-cli.
 [drivers.mysql]
-# No fields implemented yet. This key is only used to validate parsing.
+# Whether to enable the `PIPES_AS_CONCAT` connection setting
+#
+# Defaults to `true`.
+#
+# Some MySql databases such as PlanetScale error out with this connection setting
+# so it needs to be set `false` in such cases.
+pipes-as-concat = false
+# Whether to enable the `NO_ENGINE_SUBSTITUTION` sql_mode setting after connection.
+#
+# Defaults to `true` (`NO_ENGINE_SUBSTITUTION` is passed, forbidding engine substitution.)
+#
+# If not set, if the available storage engine specified by a `CREATE TABLE` is not available,
+# a warning is given and the default storage engine is used instead.
+no-engine-substitution = false
 
 # Configure Postgres databases in macros and sqlx-cli.
 [drivers.postgres]

--- a/sqlx-core/src/config/reference.toml
+++ b/sqlx-core/src/config/reference.toml
@@ -22,7 +22,24 @@ database-url-var = "FOO_DATABASE_URL"
 
 # Configure MySQL databases in macros and sqlx-cli.
 [drivers.mysql]
-# No fields implemented yet. This key is only used to validate parsing.
+# Whether to enable the `PIPES_AS_CONCAT` connection setting.
+#
+# Defaults to `true`.
+#
+# Some MySql databases such as PlanetScale error out with this connection setting
+# so it needs to be set `false` in such cases.
+#
+# Must be specified separately at run-time using `MySqlConnectOptions::pipes_as_concat()`.
+pipes-as-concat = false
+# Whether to enable the `NO_ENGINE_SUBSTITUTION` sql_mode setting after connection.
+#
+# Defaults to `true` (`NO_ENGINE_SUBSTITUTION` is passed, forbidding engine substitution.)
+#
+# If not set, if the available storage engine specified by a `CREATE TABLE` is not available,
+# a warning is given and the default storage engine is used instead.
+#
+# Must be specified separately at run-time using `MySqlConnectOptions::no_engine_substitution()`.
+no-engine-substitution = false
 
 # Configure Postgres databases in macros and sqlx-cli.
 [drivers.postgres]

--- a/sqlx-core/src/config/tests.rs
+++ b/sqlx-core/src/config/tests.rs
@@ -18,6 +18,9 @@ fn assert_common_config(config: &config::common::Config) {
 }
 
 fn assert_drivers_config(config: &config::drivers::Config) {
+    assert!(!config.mysql.pipes_as_concat);
+    assert!(!config.mysql.no_engine_substitution);
+
     assert_eq!(
         config.sqlite.unsafe_load_extensions,
         vec![

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -179,6 +179,29 @@ pub trait Connection: Send {
         async move { Self::connect_with(&options?).await }
     }
 
+    /// UNSTABLE: for use with `sqlx-macros-core`
+    ///
+    /// Establish a new database connection.
+    ///
+    /// A value of [`Options`][Self::Options] is first parsed from the provided connection string.
+    /// This parsing is database-specific.
+    /// The option then gets updated with options from the sqlx.toml file as appropriate.
+    #[doc(hidden)]
+    #[inline]
+    fn connect_with_driver_config(
+        url: &str,
+        driver_config: &config::drivers::Config,
+    ) -> impl Future<Output = Result<Self, Error>> + Send + 'static
+    where
+        Self: Sized,
+    {
+        let options = url
+            .parse::<Self::Options>()
+            .and_then(|options| options.__unstable_apply_driver_config(driver_config));
+
+        async move { Self::connect_with(&options?).await }
+    }
+
     /// Establish a new database connection with the provided options.
     fn connect_with(
         options: &Self::Options,

--- a/sqlx-macros-core/src/database/mod.rs
+++ b/sqlx-macros-core/src/database/mod.rs
@@ -62,7 +62,7 @@ impl<DB: DatabaseExt> CachingDescribeBlocking<DB> {
         &self,
         query: &str,
         database_url: &str,
-        _driver_config: &config::drivers::Config,
+        driver_config: &config::drivers::Config,
     ) -> sqlx_core::Result<Describe<DB>>
     where
         for<'a> &'a mut DB::Connection: Executor<'a, Database = DB>,
@@ -76,7 +76,10 @@ impl<DB: DatabaseExt> CachingDescribeBlocking<DB> {
             let conn = match cache.entry(database_url.to_string()) {
                 hash_map::Entry::Occupied(hit) => hit.into_mut(),
                 hash_map::Entry::Vacant(miss) => {
-                    let conn = miss.insert(DB::Connection::connect(database_url).await?);
+                    let conn = miss.insert(
+                        DB::Connection::connect_with_driver_config(database_url, driver_config)
+                            .await?,
+                    );
                     DB::prepare_describe_connection(conn).await?;
                     conn
                 }

--- a/sqlx-mysql/src/options/connect.rs
+++ b/sqlx-mysql/src/options/connect.rs
@@ -4,7 +4,7 @@ use crate::executor::Executor;
 use crate::{MySqlConnectOptions, MySqlConnection};
 use log::LevelFilter;
 use sqlx_core::sql_str::AssertSqlSafe;
-use sqlx_core::Url;
+use sqlx_core::{config, Url};
 use std::time::Duration;
 
 impl ConnectOptions for MySqlConnectOptions {
@@ -99,5 +99,12 @@ impl ConnectOptions for MySqlConnectOptions {
     fn log_slow_statements(mut self, level: LevelFilter, duration: Duration) -> Self {
         self.log_settings.log_slow_statements(level, duration);
         self
+    }
+
+    fn __unstable_apply_driver_config(
+        self,
+        config: &config::drivers::Config,
+    ) -> crate::Result<Self> {
+        self.apply_driver_config(&config.mysql)
     }
 }

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -5,6 +5,7 @@ mod parse;
 mod ssl_mode;
 
 use crate::{connection::LogSettings, net::tls::CertificateInput};
+use sqlx_core::config;
 pub use ssl_mode::MySqlSslMode;
 
 /// Options and flags which can be used to configure a MySQL connection.
@@ -413,6 +414,17 @@ impl MySqlConnectOptions {
     pub fn set_names(mut self, flag_val: bool) -> Self {
         self.set_names = flag_val;
         self
+    }
+
+    pub(crate) fn apply_driver_config(
+        mut self,
+        config: &config::drivers::MySqlConfig,
+    ) -> crate::Result<Self> {
+        self = self
+            .pipes_as_concat(config.pipes_as_concat)
+            .no_engine_substitution(config.no_engine_substitution);
+
+        Ok(self)
     }
 }
 

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -8,7 +8,7 @@ mod parse;
 mod ssl_mode;
 
 use crate::{connection::LogSettings, net::tls::CertificateInput};
-use sqlx_core::net::tls::TlsConnector;
+use sqlx_core::{config, net::tls::TlsConnector};
 pub use ssl_mode::MySqlSslMode;
 
 /// Options and flags which can be used to configure a MySQL connection.
@@ -446,6 +446,17 @@ impl MySqlConnectOptions {
     pub fn found_rows(mut self, flag_val: bool) -> Self {
         self.found_rows = flag_val;
         self
+    }
+
+    pub(crate) fn apply_driver_config(
+        mut self,
+        config: &config::drivers::MySqlConfig,
+    ) -> crate::Result<Self> {
+        self = self
+            .pipes_as_concat(config.pipes_as_concat)
+            .no_engine_substitution(config.no_engine_substitution);
+
+        Ok(self)
     }
 }
 


### PR DESCRIPTION
### Does your PR solve an issue?
related #3205

This PR makes two MySQL connection options configurable through `sqlx.toml`, which are essential to some databases like StarRocks to be used with the SQLx CLI and the query macros.

### Is this a breaking change?
No. It only adds new methods and config options. Users don't get affected unless they explicitly opt in to using `sqlx.toml` with the added config options. Defaults remain consistent.