### PR TITLE
Add support for setting a default migrator

### DIFF
--- a/sqlx-core/src/config/migrate.rs
+++ b/sqlx-core/src/config/migrate.rs
@@ -116,6 +116,19 @@ pub struct Config {
 
     /// Specify default options for new migrations created with `sqlx migrate add`.
     pub defaults: MigrationDefaults,
+    /// Default migrator used for tests.
+    pub default_migrator: Option<DefaultMigrator>,
+}
+
+#[derive(Debug)]
+#[cfg_attr(
+    feature = "sqlx-toml",
+    derive(serde::Deserialize),
+    serde(rename_all = "kebab-case", deny_unknown_fields, untagged)
+)]
+pub enum DefaultMigrator {
+    /// A single path to a migrator, e.g. `crate::foo::MIGRATOR`.
+    Path(String),
 }
 
 #[derive(Debug, Default)]

--- a/sqlx-macros-core/src/test_attr.rs
+++ b/sqlx-macros-core/src/test_attr.rs
@@ -149,15 +149,27 @@ fn expand_advanced(args: AttributeArgs, input: syn::ItemFn) -> crate::Result<Tok
             quote! { args.migrator(&#migrator); }
         }
         MigrationsOpt::InferredPath if !inputs.is_empty() => {
-            let path = crate::migrate::default_path(&config);
-
-            let resolved_path = crate::common::resolve_path(path, proc_macro2::Span::call_site())?;
-
-            if resolved_path.is_dir() {
-                let migrator = crate::migrate::expand_with_path(&config, &resolved_path)?;
-                quote! { args.migrator(&#migrator); }
+            if let Some(migrator) = config.migrate.default_migrator {
+                match migrator {
+                    sqlx_core::config::migrate::DefaultMigrator::Path(path) => {
+                        let path: syn::Path = syn::parse_str(&path).unwrap_or_else(|e| {
+                            panic!("Cannot parse default migrator {path} as a Rust path: {e:?}")
+                        });
+                        quote! { args.migrator(&#path); }
+                    }
+                }
             } else {
-                quote! {}
+                let path = crate::migrate::default_path(&config);
+
+                let resolved_path =
+                    crate::common::resolve_path(path, proc_macro2::Span::call_site())?;
+
+                if resolved_path.is_dir() {
+                    let migrator = crate::migrate::expand_with_path(&config, &resolved_path)?;
+                    quote! { args.migrator(&#migrator); }
+                } else {
+                    quote! {}
+                }
             }
         }
         MigrationsOpt::ExplicitMigrator(path) => {


### PR DESCRIPTION
This PR contains an implementation sketch for setting a default migrator for `#[sqlx::test]` macros, because repeating all the migrations for each such macro can produce a lot of code bloat and slow compilation times (see https://github.com/transact-rs/sqlx/issues/4318 and https://kobzol.github.io/rust/2026/06/21/optimizing-sqlx-test-rebuild-time.html for more details).

It is configured in the config:
```toml
[migrate]
default-migrator = "crate::MIGRATOR"
```

When a `#[sqlx::test]` macro doesn't specify the `migrations` nor the `migrator` field, and a default migrator is set, it will load it the migrations from it (via a Rust path), rather than inlining the migrations in the expanded `#[sqlx::test]` output.

So it turns from
```rust
let mut args = ::sqlx::testing::TestArgs::new("foo::foo");
    args . migrator (& :: sqlx :: migrate :: Migrator { migrations : :: std :: borrow :: Cow :: Borrowed (const { & [:: sqlx :: migrate :: Migration { version : 20260630083325i64 , description : :: std :: borrow :: Cow :: Borrowed ("migration-1") , migration_type : :: sqlx :: migrate :: MigrationType :: Simple , sql : :: sqlx :: SqlStr :: from_static ("-- Add migration script here\nCREATE TABLE users\n(\n    id   SERIAL,\n    name TEXT\n);\n") , no_tx : false , checksum : :: std :: borrow :: Cow :: Borrowed (& [119u8 , 109u8 , 53u8 , 188u8 , 84u8 , 113u8 , 67u8 , 160u8 , 82u8 , 175u8 , 115u8 , 185u8 , 158u8 , 182u8 , 47u8 , 152u8 , 38u8 , 62u8 , 17u8 , 118u8 , 9u8 , 171u8 , 33u8 , 240u8 , 65u8 , 122u8 , 28u8 , 220u8 , 134u8 , 210u8 , 109u8 , 200u8 , 153u8 , 114u8 , 45u8 , 248u8 , 16u8 , 243u8 , 46u8 , 141u8 , 77u8 , 117u8 , 201u8 , 65u8 , 160u8 , 30u8 , 50u8 , 195u8]) , }] }) , create_schemas : :: std :: borrow :: Cow :: Borrowed (& []) , table_name : :: std :: borrow :: Cow :: Borrowed ("_sqlx_migrations") , .. :: sqlx :: migrate :: Migrator :: DEFAULT }) ; 

// potentially kilobytes of migrations embedded here
```

to

```rust
let mut args = ::sqlx::testing::TestArgs::new("foo::foo");
args.migrator(&crate::MIGRATOR);
```

I'm not sure in which config section this makes the most sense, so far I added it to the default `migrate` section, but maybe it should have a new dedicated `test` section?

I didn't write tests or document the config option yet, because I first wanted to get a vibe check whether you find the approach reasonable.

TODO:
- [ ] Tests
- [ ] Document the new config
- [ ] Allow specifying a default migrator per crate (?)

### Does your PR solve an issue?
Fixes: https://github.com/transact-rs/sqlx/issues/4318

### Is this a breaking change?
No, it is a new opt-in option in the sqlx TOML config.
