### PR TITLE
fix(sqlite): don't panic building URL for in-memory connect options

### DIFF
--- a/sqlx-sqlite/src/options/parse.rs
+++ b/sqlx-sqlite/src/options/parse.rs
@@ -126,7 +126,12 @@ impl SqliteConnectOptions {
             .add(b'?')
             .add(b'`')
             .add(b'{')
-            .add(b'}');
+            .add(b'}')
+            // Not part of the WHATWG path-percent-encode-set, but a raw `:` right after
+            // `sqlite://` gets parsed as a host:port separator instead of part of the path,
+            // which breaks in-memory filenames like `:memory:` or `file:sqlx-in-memory-0`
+            // (see `from_db_and_params`) with `EmptyHost`/`InvalidPort` errors.
+            .add(b':');
 
         let filename_encoded = percent_encode(
             self.filename.as_os_str().as_encoded_bytes(),
@@ -226,6 +231,34 @@ fn it_returns_the_parsed_url() -> Result<(), Error> {
 
     let expected_url = Url::parse(url).unwrap();
     assert_eq!(options.build_url(), expected_url);
+
+    Ok(())
+}
+
+// https://github.com/launchbadge/sqlx/issues/4327
+#[test]
+fn build_url_does_not_panic_for_in_memory_db() -> Result<(), Error> {
+    // filename is `file:sqlx-in-memory-{seqno}`, which used to make the `url` crate
+    // interpret everything up to the next `/` as a `host:port` authority and choke on
+    // `sqlx-in-memory-0` not being a valid port.
+    let options: SqliteConnectOptions = "sqlite::memory:".parse()?;
+    let url = options.build_url();
+    assert_eq!(
+        url.query_pairs().find(|(k, _)| k == "mode").unwrap().1,
+        "memory"
+    );
+
+    // the plain `:memory:` filename used by `SqliteConnectOptions::default()` hit the same
+    // problem (the leading `:` was parsed as an empty host).
+    let default_url = SqliteConnectOptions::default().build_url();
+    assert_eq!(
+        default_url
+            .query_pairs()
+            .find(|(k, _)| k == "mode")
+            .unwrap()
+            .1,
+        "rw"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
`SqliteConnectOptions::to_url_lossy()` panics for in-memory databases. The filename for an in-memory DB is either `:memory:` (the default) or the generated `file:sqlx-in-memory-N`, and `build_url()`'s percent-encode set doesn't touch `:`, so it ends up embedding a raw colon right after `sqlite://`. The `url` crate then reads that as a `host:port` authority instead of a path and dies with `InvalidPort` (or `EmptyHost` for the plain `:memory:` case).

```rust
sqlx::sqlite::SqliteConnectOptions::from_str("sqlite::memory:")?.to_url_lossy(); // panics
```

Fixed by adding `:` to the encode set used when building the URL — it's not part of the WHATWG path-percent-encode-set this was modeled on, but it needs to go since it's ambiguous with authority syntax right after the scheme. Doesn't affect normal file paths since those don't have a leading colon problem. Added a test that hits both the `:memory:` default and the `file:sqlx-in-memory-N` path, confirmed it panics on main and passes with the fix.

Closes #4327