### PR TITLE
feat: add ability to set or unset the CLIENT_FOUND_ROWS flag

### DIFF
--- a/sqlx-mysql/src/connection/stream.rs
+++ b/sqlx-mysql/src/connection/stream.rs
@@ -35,7 +35,6 @@ impl<S: Socket> MySqlStream<S> {
         let mut capabilities = Capabilities::PROTOCOL_41
             | Capabilities::IGNORE_SPACE
             | Capabilities::DEPRECATE_EOF
-            | Capabilities::FOUND_ROWS
             | Capabilities::TRANSACTIONS
             | Capabilities::SECURE_CONNECTION
             | Capabilities::PLUGIN_AUTH_LENENC_DATA
@@ -47,6 +46,10 @@ impl<S: Socket> MySqlStream<S> {
 
         if options.database.is_some() {
             capabilities |= Capabilities::CONNECT_WITH_DB;
+        }
+
+        if options.found_rows {
+            capabilities |= Capabilities::FOUND_ROWS;
         }
 
         Self {

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -80,6 +80,7 @@ pub struct MySqlConnectOptions {
     pub(crate) no_engine_substitution: bool,
     pub(crate) timezone: Option<String>,
     pub(crate) set_names: bool,
+    pub(crate) found_rows: bool,
 }
 
 impl Default for MySqlConnectOptions {
@@ -111,6 +112,7 @@ impl MySqlConnectOptions {
             no_engine_substitution: true,
             timezone: Some(String::from("+00:00")),
             set_names: true,
+            found_rows: true,
         }
     }
 
@@ -412,6 +414,15 @@ impl MySqlConnectOptions {
     /// [`.charset`]: Self::charset()
     pub fn set_names(mut self, flag_val: bool) -> Self {
         self.set_names = flag_val;
+        self
+    }
+
+    /// Sets the flag that enables or disables CLIENT_FOUND_ROWS,
+    /// to return the number of found (matched) rows, and not the number of changed rows.
+    ///
+    /// The default value is set to true.
+    pub fn found_rows(mut self, flag_val: bool) -> Self {
+        self.found_rows = flag_val;
         self
     }
 }

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -727,3 +727,55 @@ async fn any_blob_conversions() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn test_client_found_rows() -> anyhow::Result<()> {
+    setup_if_needed();
+
+    let url = url::Url::parse(&env::var("DATABASE_URL")?)?;
+
+    // CLIENT_AFFECTED_ROWS unspecified = true by default.
+    let mut conn = MySqlConnectOptions::from_url(&url)?.connect().await?;
+    let mut tx = conn.begin().await?;
+
+    tx.execute(sqlx::query(
+        "CREATE TEMPORARY TABLE found_rows_testing (id INT PRIMARY KEY, field INT NOT NULL)",
+    ))
+    .await?;
+
+    let result = tx.execute(sqlx::query("INSERT INTO found_rows_testing VALUES (0, 10) ON DUPLICATE KEY UPDATE field = VALUES(field)")).await?;
+    assert_eq!(result.rows_affected(), 1);
+
+    let result = tx.execute(sqlx::query("INSERT INTO found_rows_testing VALUES (0, 10) ON DUPLICATE KEY UPDATE field = VALUES(field)")).await?;
+    assert_eq!(result.rows_affected(), 1);
+
+    let result = tx.execute(sqlx::query("INSERT INTO found_rows_testing VALUES (0, 20) ON DUPLICATE KEY UPDATE field = VALUES(field)")).await?;
+    assert_eq!(result.rows_affected(), 2);
+
+    tx.rollback().await?;
+
+    // Explicitly unset CLIENT_AFFECTED_ROWS.
+    let mut conn = MySqlConnectOptions::from_url(&url)?
+        .found_rows(false)
+        .connect()
+        .await?;
+    let mut tx = conn.begin().await?;
+
+    tx.execute(sqlx::query(
+        "CREATE TEMPORARY TABLE found_rows_testing (id INT PRIMARY KEY, field INT NOT NULL)",
+    ))
+    .await?;
+
+    let result = tx.execute(sqlx::query("INSERT INTO found_rows_testing VALUES (0, 10) ON DUPLICATE KEY UPDATE field = VALUES(field)")).await?;
+    assert_eq!(result.rows_affected(), 1);
+
+    let result = tx.execute(sqlx::query("INSERT INTO found_rows_testing VALUES (0, 10) ON DUPLICATE KEY UPDATE field = VALUES(field)")).await?;
+    assert_eq!(result.rows_affected(), 0);
+
+    let result = tx.execute(sqlx::query("INSERT INTO found_rows_testing VALUES (0, 20) ON DUPLICATE KEY UPDATE field = VALUES(field)")).await?;
+    assert_eq!(result.rows_affected(), 2);
+
+    tx.rollback().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #3063.

### Is this a breaking change?

No: it preserves current SQLx behavior.

### Context

We are developing an application with "upsert" (update or insert) semantics: each request should either update an existing row or insert a new one if no matching row exists.

To implement this behavior, we use MySQL statements of the form INSERT ... ON DUPLICATE KEY UPDATE:
https://dev.mysql.com/doc/refman/8.4/en/insert-on-duplicate.html

> With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 1 if the row is inserted as a new row, 2 if an existing row is updated, and 0 if an existing row is set to its current values. If you specify the CLIENT_FOUND_ROWS flag to the mysql_real_connect() C API function when connecting to mysqld, the affected-rows value is 1 (not 0) if an existing row is set to its current values.

SQLx currently enables the MySQL CLIENT_FOUND_ROWS flag by default:
https://github.com/transact-rs/sqlx/blob/main/sqlx-mysql/src/connection/stream.rs#L38

which makes it impossible to distinguish whether a row was inserted as a new row or set to its current values,
because in both cases MySQL reports affected_rows = 1 when CLIENT_FOUND_ROWS is enabled.

This PR preserves current SQLx behavior, as the `found_rows` variable is set to true by default.