### PR TITLE
fix(sqlite): correct sub-second decoding of pre-epoch REAL datetimes

### DIFF
--- a/sqlx-sqlite/src/types/chrono.rs
+++ b/sqlx-sqlite/src/types/chrono.rs
@@ -176,10 +176,16 @@ fn decode_datetime_from_float(value: f64) -> Option<DateTime<FixedOffset>> {
     // We checked above if the value is infinite or NaN which could otherwise cause problems
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     {
-        let seconds = timestamp.trunc() as i64;
-        let nanos = (timestamp.fract() * 1E9).abs() as u32;
+        // Split into whole seconds and a non-negative sub-second remainder.
+        // `timestamp_opt` always adds `nanos` *forward* in time, so we must round
+        // `seconds` toward negative infinity (not toward zero) and take the
+        // fraction relative to that. Using `trunc()`/`fract().abs()` here would
+        // push pre-epoch timestamps up to ~2 seconds off (and onto the wrong side
+        // of the epoch), since the fractional part is negative below zero.
+        let seconds = timestamp.floor();
+        let nanos = ((timestamp - seconds) * 1E9) as u32;
 
-        Utc.fix().timestamp_opt(seconds, nanos).single()
+        Utc.fix().timestamp_opt(seconds as i64, nanos).single()
     }
 }
 
@@ -216,5 +222,59 @@ impl<'r> Decode<'r, Sqlite> for NaiveTime {
         }
 
         Err(format!("invalid time: {value}").into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_datetime_from_float;
+    use chrono::{Offset, TimeZone, Utc};
+
+    // SQLite may store a datetime as a REAL holding a Julian day number, e.g. the
+    // result of `julianday(...)`. This mirrors that conversion so a test can feed
+    // `decode_datetime_from_float` the value for a known instant.
+    fn julian_day(unix_seconds: f64) -> f64 {
+        2_440_587.5 + unix_seconds / 86_400.0
+    }
+
+    // Assert that the Julian day for `unix_seconds + subsec_nanos` decodes back to
+    // that same instant. The tolerance only absorbs f64 round-off in the
+    // round-trip (tens of microseconds), well below the errors under test.
+    #[track_caller]
+    fn assert_decodes_near(unix_seconds: i64, subsec_nanos: u32) {
+        let input = julian_day(unix_seconds as f64 + f64::from(subsec_nanos) / 1e9);
+        let decoded = decode_datetime_from_float(input).expect("valid Julian day should decode");
+        let expected = Utc
+            .fix()
+            .timestamp_opt(unix_seconds, subsec_nanos)
+            .single()
+            .unwrap();
+
+        let diff_us = (decoded - expected)
+            .num_microseconds()
+            .expect("difference fits in microseconds")
+            .abs();
+        assert!(
+            diff_us < 1_000,
+            "decoded {decoded} differs from expected {expected} by {diff_us} us",
+        );
+    }
+
+    // A Julian day landing before the UNIX epoch must keep its sub-second part in
+    // the correct direction. Before the fix these decoded up to ~2 seconds off,
+    // and could even cross to the wrong side of the epoch.
+    #[test]
+    fn decodes_pre_epoch_float_datetime() {
+        // 1969-12-31 23:59:59.500 UTC
+        assert_decodes_near(-1, 500_000_000);
+        // 1969-12-31 23:59:58.750 UTC
+        assert_decodes_near(-2, 750_000_000);
+    }
+
+    // Post-epoch values were already correct; guard against a regression.
+    #[test]
+    fn decodes_post_epoch_float_datetime() {
+        // 1970-01-01 00:00:01.500 UTC
+        assert_decodes_near(1, 500_000_000);
     }
 }


### PR DESCRIPTION
SQLite can store a datetime as a REAL holding a Julian day number, for example
the result of `julianday(...)`. When such a value is read back into a `chrono`
type, `decode_datetime_from_float` converts the Julian day to a UNIX timestamp
and then splits it into whole seconds and nanoseconds:

```rust
let seconds = timestamp.trunc() as i64;
let nanos = (timestamp.fract() * 1E9).abs() as u32;
Utc.fix().timestamp_opt(seconds, nanos).single()
```

`timestamp_opt` always adds `nanos` *forward* in time. For timestamps before
the epoch the fractional part is negative, so `trunc()` (which rounds toward
zero) together with `fract().abs()` moves the result in the wrong direction.
The decoded instant ends up as much as ~2 seconds off, and for values in the
last second before the epoch it lands on the wrong side of it entirely. For
instance `1969-12-31 23:59:59.5` decodes as `1970-01-01 00:00:00.5`.

The fix rounds the seconds toward negative infinity with `floor()` and takes
the sub-second remainder relative to that floor, so `nanos` is always a valid
non-negative forward offset:

```rust
let seconds = timestamp.floor();
let nanos = ((timestamp - seconds) * 1E9) as u32;
Utc.fix().timestamp_opt(seconds as i64, nanos).single()
```

Values at or after the epoch are unchanged, since there `floor()` equals
`trunc()` and the fraction is already non-negative. The integer decode path
(`decode_datetime_from_int`) was already exact for whole seconds; this brings
the REAL path in line with it.

Added unit tests in `sqlx-sqlite/src/types/chrono.rs` covering a pre-epoch
value with a sub-second component (which fails before this change and passes
after) and a post-epoch value (guarding against a regression). I also
confirmed the end-to-end path with an in-memory
`SELECT julianday('1969-12-31 23:59:59.500')` read as `DateTime<Utc>`: before
the change it returns `1970-01-01 00:00:00.500`, after it returns
`1969-12-31 23:59:59.500` (to within f64 round-off).

### Does your PR solve an issue?

No linked issue. I came across this while looking at how the REAL/Julian-day
storage class is decoded; the existing datetime tests only cover the TEXT
formats, so this path was untested.

### Is this a breaking change?

No. This is a correctness fix. It does change the decoded value for pre-1970
datetimes stored as REAL Julian day numbers, but only from an incorrect value
to the correct one; the public API is unchanged and post-epoch values are
unaffected.
