### PR TITLE
tracing::instrument a fair bit of the repo

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -88,6 +88,7 @@ futures-util = { version = "0.3.32", default-features = false, features = ["allo
 log = { version = "0.4.18", default-features = false }
 memchr = { version = "2.5.0", default-features = false }
 percent-encoding = "2.3.0"
+pin-project-lite = "0.2.16"
 serde = { version = "1.0.219", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0.142", features = ["raw_value"], optional = true }
 toml = { version = "0.8.16", optional = true }

--- a/sqlx-core/src/instrument_stream.rs
+++ b/sqlx-core/src/instrument_stream.rs
@@ -1,0 +1,52 @@
+//! Attach a [`tracing::Span`] to a [`Stream`] so the span stays open for the
+//! whole stream rather than just its construction.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+use pin_project_lite::pin_project;
+use tracing::Span;
+
+pin_project! {
+    /// A [`Stream`] adapter that enters `span` for the duration of every
+    /// [`poll_next`](Stream::poll_next).
+    ///
+    /// A plain `#[tracing::instrument]` on an `async fn` that *returns* a stream
+    /// only keeps its span entered while the stream is being built; the span is
+    /// then closed before the caller ever polls the stream. Wrapping the
+    /// returned stream with this adapter instead keeps the span open across row
+    /// fetching, so e.g. a `sqlx::query` span measures the whole query rather
+    /// than just its setup.
+    pub struct InstrumentedStream<S> {
+        #[pin]
+        stream: S,
+        span: Span,
+    }
+}
+
+impl<S: Stream> Stream for InstrumentedStream<S> {
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        let _entered = this.span.enter();
+        this.stream.poll_next(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+}
+
+/// Extension trait for attaching a [`Span`] to a [`Stream`].
+pub trait InstrumentStream: Stream + Sized {
+    /// Wrap this stream so that `span` is entered every time it is polled.
+    ///
+    /// See [`InstrumentedStream`].
+    fn instrument_stream(self, span: Span) -> InstrumentedStream<Self> {
+        InstrumentedStream { stream: self, span }
+    }
+}
+
+impl<S: Stream> InstrumentStream for S {}

--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -66,6 +66,7 @@ pub mod describe;
 pub mod executor;
 pub mod from_row;
 pub mod fs;
+pub mod instrument_stream;
 pub mod io;
 pub mod logger;
 pub mod net;

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -224,6 +224,17 @@ impl Migrator {
 
     // Getting around the annoying "implementation of `Acquire` is not general enough" error
     #[doc(hidden)]
+    #[tracing::instrument(
+        target = "sqlx::migrate",
+        name = "migrate.run",
+        skip_all,
+        fields(
+            migrate.target = target,
+            migrate.skip = skip,
+            migrate.table = %self.table_name,
+            migrate.known = self.migrations.len(),
+        ),
+    )]
     pub async fn run_direct<C>(
         &self,
         target: Option<i64>,
@@ -235,6 +246,7 @@ impl Migrator {
     {
         // lock the database for exclusive access by the migrator
         if self.locking {
+            tracing::debug!(target: "sqlx::migrate", "acquiring migration lock");
             conn.lock().await?;
         }
 
@@ -277,8 +289,21 @@ impl Migrator {
                 }
                 None => {
                     if skip {
+                        tracing::info!(
+                            target: "sqlx::migrate",
+                            version = migration.version,
+                            description = %migration.description,
+                            "skipping migration (marking as applied without running)",
+                        );
                         conn.skip(&self.table_name, migration).await?;
                     } else {
+                        tracing::info!(
+                            target: "sqlx::migrate",
+                            version = migration.version,
+                            description = %migration.description,
+                            migration_type = ?migration.migration_type,
+                            "applying migration",
+                        );
                         conn.apply(&self.table_name, migration).await?;
                     }
                 }
@@ -288,6 +313,7 @@ impl Migrator {
         // unlock the migrator to allow other migrators to run
         // but do nothing as we already migrated
         if self.locking {
+            tracing::debug!(target: "sqlx::migrate", "releasing migration lock");
             conn.unlock().await?;
         }
 
@@ -311,6 +337,12 @@ impl Migrator {
     /// #     })
     /// # }
     /// ```
+    #[tracing::instrument(
+        target = "sqlx::migrate",
+        name = "migrate.undo",
+        skip_all,
+        fields(migrate.target = target, migrate.table = %self.table_name),
+    )]
     pub async fn undo<'a, A>(&self, migrator: A, target: i64) -> Result<(), MigrateError>
     where
         A: Acquire<'a>,
@@ -320,6 +352,7 @@ impl Migrator {
 
         // lock the database for exclusive access by the migrator
         if self.locking {
+            tracing::debug!(target: "sqlx::migrate", "acquiring migration lock");
             conn.lock().await?;
         }
 
@@ -347,12 +380,19 @@ impl Migrator {
             .filter(|m| applied_migrations.contains_key(&m.version))
             .filter(|m| m.version > target)
         {
+            tracing::info!(
+                target: "sqlx::migrate",
+                version = migration.version,
+                description = %migration.description,
+                "reverting migration",
+            );
             conn.revert(&self.table_name, migration).await?;
         }
 
         // unlock the migrator to allow other migrators to run
         // but do nothing as we already migrated
         if self.locking {
+            tracing::debug!(target: "sqlx::migrate", "releasing migration lock");
             conn.unlock().await?;
         }
 

--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -243,6 +243,17 @@ impl<DB: Database> PoolInner<DB> {
         }
     }
 
+    #[tracing::instrument(
+        target = "sqlx::pool::acquire",
+        name = "pool.acquire",
+        skip_all,
+        fields(
+            pool.size = self.size(),
+            pool.idle = self.num_idle(),
+            pool.max = self.options.max_connections,
+        ),
+        level = "debug",
+    )]
     pub(super) async fn acquire(self: &Arc<Self>) -> Result<Floating<DB, Live<DB>>, Error> {
         if self.is_closed() {
             return Err(Error::PoolClosed);
@@ -322,6 +333,13 @@ impl<DB: Database> PoolInner<DB> {
         Ok(acquired)
     }
 
+    #[tracing::instrument(
+        target = "sqlx::pool::connect",
+        name = "pool.connect",
+        skip_all,
+        fields(pool.size = self.size()),
+        level = "debug",
+    )]
     pub(super) async fn connect(
         self: &Arc<Self>,
         deadline: Instant,

--- a/sqlx-core/src/transaction.rs
+++ b/sqlx-core/src/transaction.rs
@@ -274,6 +274,11 @@ where
             // operation that will happen on the next asynchronous invocation of the underlying
             // connection (including if the connection is returned to a pool)
 
+            tracing::debug!(
+                target: "sqlx::transaction",
+                "transaction dropped without explicit commit/rollback; queueing implicit rollback",
+            );
+
             DB::TransactionManager::start_rollback(&mut self.connection);
         }
     }

--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -26,7 +26,6 @@ impl MySqlConnection {
         level = "debug",
     )]
     pub(crate) async fn establish(options: &MySqlConnectOptions) -> Result<Self, Error> {
-        tracing::debug!("establishing MySQL connection");
         let do_handshake = DoHandshake::new(options)?;
 
         let handshake = match &options.socket {

--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -12,7 +12,21 @@ use crate::protocol::Capabilities;
 use crate::{MySqlConnectOptions, MySqlConnection, MySqlSslMode};
 
 impl MySqlConnection {
+    #[tracing::instrument(
+        target = "sqlx::connect",
+        name = "mysql.establish",
+        skip_all,
+        fields(
+            db.system = "mysql",
+            server.address = %options.host,
+            server.port = options.port,
+            db.name = options.database.as_deref().unwrap_or_default(),
+            db.user = %options.username,
+        ),
+        level = "debug",
+    )]
     pub(crate) async fn establish(options: &MySqlConnectOptions) -> Result<Self, Error> {
+        tracing::debug!("establishing MySQL connection");
         let do_handshake = DoHandshake::new(options)?;
 
         let handshake = match &options.socket {
@@ -21,6 +35,11 @@ impl MySqlConnection {
         };
 
         let stream = handshake?;
+
+        tracing::debug!(
+            server_version = ?stream.server_version,
+            "MySQL connection established"
+        );
 
         Ok(Self {
             inner: Box::new(MySqlConnectionInner {

--- a/sqlx-mysql/src/connection/executor.rs
+++ b/sqlx-mysql/src/connection/executor.rs
@@ -21,6 +21,7 @@ use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
 use futures_core::Stream;
 use futures_util::TryStreamExt;
+use sqlx_core::arguments::Arguments as _;
 use sqlx_core::column::{ColumnOrigin, TableColumn};
 use sqlx_core::sql_str::SqlStr;
 use std::{pin::pin, sync::Arc};
@@ -116,7 +117,7 @@ impl MySqlConnection {
         skip_all,
         fields(
             db.system = "mysql",
-            db.operation.parameters = arguments.as_ref().map_or(0, |a| a.types.len()),
+            db.operation.parameters = arguments.as_ref().map_or(0, |a| a.len()),
             db.mysql.prepared = arguments.is_some(),
         ),
         level = "debug",

--- a/sqlx-mysql/src/connection/executor.rs
+++ b/sqlx-mysql/src/connection/executor.rs
@@ -26,6 +26,13 @@ use sqlx_core::sql_str::SqlStr;
 use std::{pin::pin, sync::Arc};
 
 impl MySqlConnection {
+    #[tracing::instrument(
+        target = "sqlx::prepare",
+        name = "mysql.prepare",
+        skip_all,
+        fields(db.system = "mysql"),
+        level = "debug",
+    )]
     async fn prepare_statement(
         &mut self,
         sql: &str,
@@ -78,9 +85,12 @@ impl MySqlConnection {
         sql: &str,
     ) -> Result<(u32, MySqlStatementMetadata), Error> {
         if let Some(statement) = self.inner.cache_statement.get_mut(sql) {
+            tracing::trace!(target: "sqlx::prepare", "prepared statement cache hit");
             // <MySqlStatementMetadata> is internally reference-counted
             return Ok((*statement).clone());
         }
+
+        tracing::trace!(target: "sqlx::prepare", "prepared statement cache miss");
 
         let (id, metadata) = self.prepare_statement(sql).await?;
 
@@ -100,6 +110,17 @@ impl MySqlConnection {
     }
 
     #[allow(clippy::needless_lifetimes)]
+    #[tracing::instrument(
+        target = "sqlx::query",
+        name = "mysql.run",
+        skip_all,
+        fields(
+            db.system = "mysql",
+            db.operation.parameters = arguments.as_ref().map_or(0, |a| a.types.len()),
+            db.mysql.prepared = arguments.is_some(),
+        ),
+        level = "debug",
+    )]
     pub(crate) async fn run<'e, 'c: 'e, 'q: 'e>(
         &'c mut self,
         sql: SqlStr,

--- a/sqlx-mysql/src/connection/executor.rs
+++ b/sqlx-mysql/src/connection/executor.rs
@@ -23,6 +23,7 @@ use futures_core::Stream;
 use futures_util::TryStreamExt;
 use sqlx_core::arguments::Arguments as _;
 use sqlx_core::column::{ColumnOrigin, TableColumn};
+use sqlx_core::instrument_stream::InstrumentStream;
 use sqlx_core::sql_str::SqlStr;
 use std::{pin::pin, sync::Arc};
 
@@ -111,17 +112,6 @@ impl MySqlConnection {
     }
 
     #[allow(clippy::needless_lifetimes)]
-    #[tracing::instrument(
-        target = "sqlx::query",
-        name = "mysql.run",
-        skip_all,
-        fields(
-            db.system = "mysql",
-            db.operation.parameters = arguments.as_ref().map_or(0, |a| a.len()),
-            db.mysql.prepared = arguments.is_some(),
-        ),
-        level = "debug",
-    )]
     pub(crate) async fn run<'e, 'c: 'e, 'q: 'e>(
         &'c mut self,
         sql: SqlStr,
@@ -129,6 +119,17 @@ impl MySqlConnection {
         persistent: bool,
     ) -> Result<impl Stream<Item = Result<Either<MySqlQueryResult, MySqlRow>, Error>> + 'e, Error>
     {
+        // The span is attached to the returned stream (see `instrument_stream`)
+        // rather than via `#[tracing::instrument]` so it stays open while rows
+        // are fetched, not just while the query is set up.
+        let span = tracing::debug_span!(
+            target: "sqlx::query",
+            "mysql.run",
+            db.system = "mysql",
+            db.operation.parameters = arguments.as_ref().map_or(0, |a| a.len()),
+            db.mysql.prepared = arguments.is_some(),
+        );
+
         let mut logger = QueryLogger::new(sql, self.inner.log_settings.clone());
 
         self.inner.stream.wait_until_ready().await?;
@@ -288,7 +289,8 @@ impl MySqlConnection {
                     r#yield!(v);
                 }
             }
-        })
+        }
+        .instrument_stream(span))
     }
 }
 

--- a/sqlx-mysql/src/connection/mod.rs
+++ b/sqlx-mysql/src/connection/mod.rs
@@ -78,7 +78,6 @@ impl Connection for MySqlConnection {
         level = "debug",
     )]
     async fn close(mut self) -> Result<(), Error> {
-        tracing::debug!("closing MySQL connection gracefully");
         self.inner.stream.send_packet(Quit).await?;
         self.inner.stream.shutdown().await?;
 

--- a/sqlx-mysql/src/connection/mod.rs
+++ b/sqlx-mysql/src/connection/mod.rs
@@ -70,7 +70,15 @@ impl Connection for MySqlConnection {
 
     type Options = MySqlConnectOptions;
 
+    #[tracing::instrument(
+        target = "sqlx::connect",
+        name = "mysql.close",
+        skip_all,
+        fields(db.system = "mysql"),
+        level = "debug",
+    )]
     async fn close(mut self) -> Result<(), Error> {
+        tracing::debug!("closing MySQL connection gracefully");
         self.inner.stream.send_packet(Quit).await?;
         self.inner.stream.shutdown().await?;
 
@@ -82,6 +90,13 @@ impl Connection for MySqlConnection {
         Ok(())
     }
 
+    #[tracing::instrument(
+        target = "sqlx::connect",
+        name = "mysql.ping",
+        skip_all,
+        fields(db.system = "mysql"),
+        level = "trace",
+    )]
     async fn ping(&mut self) -> Result<(), Error> {
         self.inner.stream.wait_until_ready().await?;
         self.inner.stream.send_packet(Ping).await?;

--- a/sqlx-mysql/src/transaction.rs
+++ b/sqlx-mysql/src/transaction.rs
@@ -14,6 +14,13 @@ pub struct MySqlTransactionManager;
 impl TransactionManager for MySqlTransactionManager {
     type Database = MySql;
 
+    #[tracing::instrument(
+        target = "sqlx::transaction",
+        name = "mysql.transaction.begin",
+        skip_all,
+        fields(db.system = "mysql", depth = conn.inner.transaction_depth),
+        level = "debug",
+    )]
     async fn begin(conn: &mut MySqlConnection, statement: Option<SqlStr>) -> Result<(), Error> {
         let depth = conn.inner.transaction_depth;
 
@@ -30,9 +37,18 @@ impl TransactionManager for MySqlTransactionManager {
         }
         conn.inner.transaction_depth += 1;
 
+        tracing::debug!("transaction/savepoint opened");
+
         Ok(())
     }
 
+    #[tracing::instrument(
+        target = "sqlx::transaction",
+        name = "mysql.transaction.commit",
+        skip_all,
+        fields(db.system = "mysql", depth = conn.inner.transaction_depth),
+        level = "debug",
+    )]
     async fn commit(conn: &mut MySqlConnection) -> Result<(), Error> {
         let depth = conn.inner.transaction_depth;
 
@@ -44,6 +60,13 @@ impl TransactionManager for MySqlTransactionManager {
         Ok(())
     }
 
+    #[tracing::instrument(
+        target = "sqlx::transaction",
+        name = "mysql.transaction.rollback",
+        skip_all,
+        fields(db.system = "mysql", depth = conn.inner.transaction_depth),
+        level = "debug",
+    )]
     async fn rollback(conn: &mut MySqlConnection) -> Result<(), Error> {
         let depth = conn.inner.transaction_depth;
 
@@ -59,6 +82,11 @@ impl TransactionManager for MySqlTransactionManager {
         let depth = conn.inner.transaction_depth;
 
         if depth > 0 {
+            tracing::debug!(
+                target: "sqlx::transaction",
+                depth,
+                "queueing implicit rollback for unfinished transaction/savepoint on drop",
+            );
             conn.inner.stream.waiting.push_back(Waiting::Result);
             conn.inner.stream.sequence_id = 0;
             conn.inner

--- a/sqlx-postgres/src/connection/establish.rs
+++ b/sqlx-postgres/src/connection/establish.rs
@@ -15,7 +15,23 @@ use super::PgConnectionInner;
 // https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.11
 
 impl PgConnection {
+    #[tracing::instrument(
+        target = "sqlx::connect",
+        name = "postgres.establish",
+        skip_all,
+        fields(
+            db.system = "postgresql",
+            server.address = %options.host,
+            server.port = options.port,
+            db.name = options.database.as_deref().unwrap_or_default(),
+            db.user = %options.username,
+            // Recorded once the startup handshake completes.
+            db.postgresql.backend_pid = tracing::field::Empty,
+        ),
+    )]
     pub(crate) async fn establish(options: &PgConnectOptions) -> Result<Self, Error> {
+        tracing::debug!("establishing PostgreSQL connection");
+
         // Upgrade to TLS if we were asked to and the server supports it
         let mut stream = PgStream::connect(options).await?;
 
@@ -122,6 +138,12 @@ impl PgConnection {
                 BackendMessageFormat::ReadyForQuery => {
                     // start-up is completed. The frontend can now issue commands
                     transaction_status = message.decode::<ReadyForQuery>()?.transaction_status;
+
+                    tracing::Span::current().record("db.postgresql.backend_pid", process_id);
+                    tracing::debug!(
+                        backend_pid = process_id,
+                        "PostgreSQL connection established"
+                    );
 
                     break;
                 }

--- a/sqlx-postgres/src/connection/establish.rs
+++ b/sqlx-postgres/src/connection/establish.rs
@@ -28,6 +28,7 @@ impl PgConnection {
             // Recorded once the startup handshake completes.
             db.postgresql.backend_pid = tracing::field::Empty,
         ),
+        level = "debug",
     )]
     pub(crate) async fn establish(options: &PgConnectOptions) -> Result<Self, Error> {
         tracing::debug!("establishing PostgreSQL connection");

--- a/sqlx-postgres/src/connection/establish.rs
+++ b/sqlx-postgres/src/connection/establish.rs
@@ -31,8 +31,6 @@ impl PgConnection {
         level = "debug",
     )]
     pub(crate) async fn establish(options: &PgConnectOptions) -> Result<Self, Error> {
-        tracing::debug!("establishing PostgreSQL connection");
-
         // Upgrade to TLS if we were asked to and the server supports it
         let mut stream = PgStream::connect(options).await?;
 

--- a/sqlx-postgres/src/connection/executor.rs
+++ b/sqlx-postgres/src/connection/executor.rs
@@ -16,6 +16,7 @@ use futures_core::stream::BoxStream;
 use futures_core::Stream;
 use futures_util::TryStreamExt;
 use sqlx_core::arguments::Arguments;
+use sqlx_core::instrument_stream::InstrumentStream;
 use sqlx_core::sql_str::SqlStr;
 use sqlx_core::Either;
 use std::{pin::pin, sync::Arc};
@@ -210,17 +211,6 @@ impl PgConnection {
         Ok(statement)
     }
 
-    #[tracing::instrument(
-        target = "sqlx::query",
-        name = "postgres.run",
-        skip_all,
-        fields(
-            db.system = "postgresql",
-            db.operation.parameters = arguments.as_ref().map_or(0, |a| a.len()),
-            db.postgresql.prepared = arguments.is_some(),
-        ),
-        level = "debug",
-    )]
     pub(crate) async fn run<'e, 'c: 'e, 'q: 'e>(
         &'c mut self,
         query: SqlStr,
@@ -228,6 +218,17 @@ impl PgConnection {
         persistent: bool,
         metadata_opt: Option<Arc<PgStatementMetadata>>,
     ) -> Result<impl Stream<Item = Result<Either<PgQueryResult, PgRow>, Error>> + 'e, Error> {
+        // The span is attached to the returned stream (see `instrument_stream`)
+        // rather than via `#[tracing::instrument]` so it stays open while rows
+        // are fetched, not just while the query is set up.
+        let span = tracing::debug_span!(
+            target: "sqlx::query",
+            "postgres.run",
+            db.system = "postgresql",
+            db.operation.parameters = arguments.as_ref().map_or(0, |a| a.len()),
+            db.postgresql.prepared = arguments.is_some(),
+        );
+
         let mut logger = QueryLogger::new(query, self.inner.log_settings.clone());
         let sql = logger.sql().as_str();
 
@@ -397,7 +398,8 @@ impl PgConnection {
             }
 
             Ok(())
-        })
+        }
+        .instrument_stream(span))
     }
 }
 

--- a/sqlx-postgres/src/connection/executor.rs
+++ b/sqlx-postgres/src/connection/executor.rs
@@ -20,6 +20,17 @@ use sqlx_core::sql_str::SqlStr;
 use sqlx_core::Either;
 use std::{pin::pin, sync::Arc};
 
+#[tracing::instrument(
+    target = "sqlx::prepare",
+    name = "postgres.prepare",
+    skip_all,
+    fields(
+        db.system = "postgresql",
+        db.operation.parameters = arg_types.len(),
+        db.postgresql.persistent = persistent,
+    ),
+    level = "debug",
+)]
 async fn prepare(
     conn: &mut PgConnection,
     sql: &str,
@@ -168,8 +179,11 @@ impl PgConnection {
         resolve_column_origin: bool,
     ) -> Result<(StatementId, Arc<PgStatementMetadata>), Error> {
         if let Some(statement) = self.inner.cache_statement.get_mut(sql) {
+            tracing::trace!(target: "sqlx::prepare", "prepared statement cache hit");
             return Ok((*statement).clone());
         }
+
+        tracing::trace!(target: "sqlx::prepare", "prepared statement cache miss");
 
         let statement = prepare(
             self,
@@ -196,6 +210,17 @@ impl PgConnection {
         Ok(statement)
     }
 
+    #[tracing::instrument(
+        target = "sqlx::query",
+        name = "postgres.run",
+        skip_all,
+        fields(
+            db.system = "postgresql",
+            db.operation.parameters = arguments.as_ref().map_or(0, |a| a.len()),
+            db.postgresql.prepared = arguments.is_some(),
+        ),
+        level = "debug",
+    )]
     pub(crate) async fn run<'e, 'c: 'e, 'q: 'e>(
         &'c mut self,
         query: SqlStr,

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -163,7 +163,7 @@ impl Connection for PgConnection {
         target = "sqlx::connect",
         name = "postgres.close",
         skip_all,
-        fields(db.system = "postgresql", backend_pid = self.inner.process_id),
+        fields(db.system = "postgresql", db.postgresql.backend_pid = self.inner.process_id),
         level = "debug",
     )]
     async fn close(mut self) -> Result<(), Error> {

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -167,7 +167,6 @@ impl Connection for PgConnection {
         level = "debug",
     )]
     async fn close(mut self) -> Result<(), Error> {
-        tracing::debug!("closing PostgreSQL connection gracefully");
         // The normal, graceful termination procedure is that the frontend sends a Terminate
         // message and immediately closes the connection.
 

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -159,7 +159,15 @@ impl Connection for PgConnection {
 
     type Options = PgConnectOptions;
 
+    #[tracing::instrument(
+        target = "sqlx::connect",
+        name = "postgres.close",
+        skip_all,
+        fields(db.system = "postgresql", backend_pid = self.inner.process_id),
+        level = "debug",
+    )]
     async fn close(mut self) -> Result<(), Error> {
+        tracing::debug!("closing PostgreSQL connection gracefully");
         // The normal, graceful termination procedure is that the frontend sends a Terminate
         // message and immediately closes the connection.
 
@@ -177,6 +185,13 @@ impl Connection for PgConnection {
         Ok(())
     }
 
+    #[tracing::instrument(
+        target = "sqlx::connect",
+        name = "postgres.ping",
+        skip_all,
+        fields(db.system = "postgresql"),
+        level = "trace",
+    )]
     async fn ping(&mut self) -> Result<(), Error> {
         // Users were complaining about this showing up in query statistics on the server.
         // By sending a comment we avoid an error if the connection was in the middle of a rowset

--- a/sqlx-postgres/src/transaction.rs
+++ b/sqlx-postgres/src/transaction.rs
@@ -14,6 +14,13 @@ pub struct PgTransactionManager;
 impl TransactionManager for PgTransactionManager {
     type Database = Postgres;
 
+    #[tracing::instrument(
+        target = "sqlx::transaction",
+        name = "postgres.transaction.begin",
+        skip_all,
+        fields(db.system = "postgresql", depth = conn.inner.transaction_depth),
+        level = "debug",
+    )]
     async fn begin(conn: &mut PgConnection, statement: Option<SqlStr>) -> Result<(), Error> {
         let depth = conn.inner.transaction_depth;
 
@@ -34,9 +41,18 @@ impl TransactionManager for PgTransactionManager {
         rollback.conn.inner.transaction_depth += 1;
         rollback.defuse();
 
+        tracing::debug!("transaction/savepoint opened");
+
         Ok(())
     }
 
+    #[tracing::instrument(
+        target = "sqlx::transaction",
+        name = "postgres.transaction.commit",
+        skip_all,
+        fields(db.system = "postgresql", depth = conn.inner.transaction_depth),
+        level = "debug",
+    )]
     async fn commit(conn: &mut PgConnection) -> Result<(), Error> {
         if conn.inner.transaction_depth > 0 {
             conn.execute(commit_ansi_transaction_sql(conn.inner.transaction_depth))
@@ -48,6 +64,13 @@ impl TransactionManager for PgTransactionManager {
         Ok(())
     }
 
+    #[tracing::instrument(
+        target = "sqlx::transaction",
+        name = "postgres.transaction.rollback",
+        skip_all,
+        fields(db.system = "postgresql", depth = conn.inner.transaction_depth),
+        level = "debug",
+    )]
     async fn rollback(conn: &mut PgConnection) -> Result<(), Error> {
         if conn.inner.transaction_depth > 0 {
             conn.execute(rollback_ansi_transaction_sql(conn.inner.transaction_depth))
@@ -61,6 +84,11 @@ impl TransactionManager for PgTransactionManager {
 
     fn start_rollback(conn: &mut PgConnection) {
         if conn.inner.transaction_depth > 0 {
+            tracing::debug!(
+                target: "sqlx::transaction",
+                depth = conn.inner.transaction_depth,
+                "queueing implicit rollback for unfinished transaction/savepoint on drop",
+            );
             conn.queue_simple_query(
                 rollback_ansi_transaction_sql(conn.inner.transaction_depth).as_str(),
             )

--- a/sqlx-sqlite/src/connection/worker.rs
+++ b/sqlx-sqlite/src/connection/worker.rs
@@ -111,7 +111,6 @@ impl ConnectionWorker {
         level = "debug",
     )]
     pub(crate) async fn establish(params: EstablishParams) -> Result<Self, Error> {
-        tracing::debug!("establishing SQLite connection worker");
         let (establish_tx, establish_rx) = oneshot::channel();
 
         thread::Builder::new()

--- a/sqlx-sqlite/src/connection/worker.rs
+++ b/sqlx-sqlite/src/connection/worker.rs
@@ -8,6 +8,7 @@ use futures_intrusive::sync::{Mutex, MutexGuard};
 use sqlx_core::sql_str::SqlStr;
 use tracing::span::Span;
 
+use sqlx_core::arguments::Arguments as _;
 use sqlx_core::error::Error;
 use sqlx_core::transaction::{
     begin_ansi_transaction_sql, commit_ansi_transaction_sql, rollback_ansi_transaction_sql,
@@ -102,7 +103,15 @@ enum Command {
 }
 
 impl ConnectionWorker {
+    #[tracing::instrument(
+        target = "sqlx::connect",
+        name = "sqlite.establish",
+        skip_all,
+        fields(db.system = "sqlite"),
+        level = "debug",
+    )]
     pub(crate) async fn establish(params: EstablishParams) -> Result<Self, Error> {
+        tracing::debug!("establishing SQLite connection worker");
         let (establish_tx, establish_rx) = oneshot::channel();
 
         thread::Builder::new()
@@ -347,6 +356,13 @@ impl ConnectionWorker {
         establish_rx.await.map_err(|_| Error::WorkerCrashed)?
     }
 
+    #[tracing::instrument(
+        target = "sqlx::prepare",
+        name = "sqlite.prepare",
+        skip_all,
+        fields(db.system = "sqlite"),
+        level = "debug",
+    )]
     pub(crate) async fn prepare(&mut self, query: SqlStr) -> Result<SqliteStatement, Error> {
         self.oneshot_cmd(|tx| Command::Prepare { query, tx })
             .await?
@@ -361,6 +377,17 @@ impl ConnectionWorker {
             .await?
     }
 
+    #[tracing::instrument(
+        target = "sqlx::query",
+        name = "sqlite.execute",
+        skip_all,
+        fields(
+            db.system = "sqlite",
+            db.operation.parameters = args.as_ref().map_or(0, |a| a.len()),
+            db.sqlite.persistent = persistent,
+        ),
+        level = "debug",
+    )]
     pub(crate) async fn execute(
         &mut self,
         query: SqlStr,
@@ -388,16 +415,37 @@ impl ConnectionWorker {
         Ok(rx)
     }
 
+    #[tracing::instrument(
+        target = "sqlx::transaction",
+        name = "sqlite.transaction.begin",
+        skip_all,
+        fields(db.system = "sqlite", depth = self.shared.get_transaction_depth()),
+        level = "debug",
+    )]
     pub(crate) async fn begin(&mut self, statement: Option<SqlStr>) -> Result<(), Error> {
         self.oneshot_cmd_with_ack(|tx| Command::Begin { tx, statement })
             .await?
     }
 
+    #[tracing::instrument(
+        target = "sqlx::transaction",
+        name = "sqlite.transaction.commit",
+        skip_all,
+        fields(db.system = "sqlite", depth = self.shared.get_transaction_depth()),
+        level = "debug",
+    )]
     pub(crate) async fn commit(&mut self) -> Result<(), Error> {
         self.oneshot_cmd_with_ack(|tx| Command::Commit { tx })
             .await?
     }
 
+    #[tracing::instrument(
+        target = "sqlx::transaction",
+        name = "sqlite.transaction.rollback",
+        skip_all,
+        fields(db.system = "sqlite", depth = self.shared.get_transaction_depth()),
+        level = "debug",
+    )]
     pub(crate) async fn rollback(&mut self) -> Result<(), Error> {
         self.oneshot_cmd_with_ack(|tx| Command::Rollback { tx: Some(tx) })
             .await?
@@ -409,6 +457,13 @@ impl ConnectionWorker {
             .map_err(|_| Error::WorkerCrashed)
     }
 
+    #[tracing::instrument(
+        target = "sqlx::connect",
+        name = "sqlite.ping",
+        skip_all,
+        fields(db.system = "sqlite"),
+        level = "trace",
+    )]
     pub(crate) async fn ping(&mut self) -> Result<(), Error> {
         self.oneshot_cmd(|tx| Command::Ping { tx }).await
     }

--- a/sqlx-sqlite/src/connection/worker.rs
+++ b/sqlx-sqlite/src/connection/worker.rs
@@ -376,6 +376,7 @@ impl ConnectionWorker {
             .await?
     }
 
+    #[allow(clippy::type_complexity)]
     #[tracing::instrument(
         target = "sqlx::query",
         name = "sqlite.execute",


### PR DESCRIPTION
I authored (TAS obviously) this PR while digging in to some performance issues in my application as we scale to hundreds of thousands of requests per minute. We're pretty bought in to the tracing ecosystem and otel, and we often see big gaps in our data that we think might be connection pool acquisition, but we weren't sure.

We deployed this PR and it raised a lot of useful metrics for us, so I'm opening it.

### Does your PR solve an issue?

No, it does not appear to have an existing issue.
However, I did open a discussion: https://github.com/transact-rs/sqlx/discussions/4341

### Is this a breaking change?

It may be a breaking change, since the stream replies return an InstrumentStream.