### PR TITLE
postgres/io: pre-allocate buffer capacity and use extend_from_slice i…

### DIFF
--- a/sqlx-postgres/src/io/buf_mut.rs
+++ b/sqlx-postgres/src/io/buf_mut.rs
@@ -19,7 +19,8 @@ impl PgBufMutExt for Vec<u8> {
     {
         // reserve space to write the prefixed length
         let offset = self.len();
-        self.extend(&[0; 4]);
+        self.reserve(4);
+        self.extend_from_slice(&[0; 4]);
 
         // write the main body of the message
         let write_result = write_contents(self);


### PR DESCRIPTION
### Summary
This PR optimizes `put_length_prefixed` in `sqlx-postgres/src/io/buf_mut.rs`.

### Rationale & Performance Benefit
Nearly all Postgres wire protocol messages sent to the database are length-prefixed. `put_length_prefixed` reserves the 4-byte length header at the beginning of each message.

Currently, it calls `self.extend(&[0; 4])`, which iterates over array elements and may trigger intermediate re-allocations if capacity is tight.

Optimizations made:
- Pre-allocates space upfront with `self.reserve(4)`.
- Uses zero-copy `self.extend_from_slice(&[0; 4])` slice copy instead of array iterator extension.
- Streamlines database wire protocol encoding for high-throughput query pipelines.