### PR TITLE
Error on .sql migration files that don't match the expected filename format

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -106,6 +106,7 @@ hashbrown = "0.16.0"
 thiserror.workspace = true
 
 [dev-dependencies]
+tempfile = "3.10.1"
 tokio = { version = "1.25.0", features = ["rt"] }
 
 [dev-dependencies.sqlx]

--- a/sqlx-core/src/config/migrate.rs
+++ b/sqlx-core/src/config/migrate.rs
@@ -114,8 +114,45 @@ pub struct Config {
     // Likely lower overhead for small sets than `HashSet`.
     pub ignored_chars: BTreeSet<char>,
 
+    /// Specify what to do with a `.sql` file in the migrations directory whose name does not
+    /// parse as `<VERSION>_<DESCRIPTION>.sql`.
+    ///
+    /// Defaults to `error`, since such a file is usually a migration that was named incorrectly
+    /// and would otherwise be skipped without any indication that it did not run.
+    ///
+    /// Set this to `warn` or `ignore` if you deliberately keep other SQL scripts alongside your
+    /// migrations. Files that don't end in `.sql` are always ignored regardless of this setting.
+    ///
+    /// ### Example
+    /// `sqlx.toml`:
+    /// ```toml
+    /// [migrate]
+    /// unrecognized-sql-files = "warn"
+    /// ```
+    pub unrecognized_sql_files: UnrecognizedSqlFiles,
+
     /// Specify default options for new migrations created with `sqlx migrate add`.
     pub defaults: MigrationDefaults,
+}
+
+/// What to do with a `.sql` file in the migrations directory that doesn't parse as
+/// `<VERSION>_<DESCRIPTION>.sql`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "sqlx-toml",
+    derive(serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
+pub enum UnrecognizedSqlFiles {
+    /// Return an error naming the file. The default.
+    #[default]
+    Error,
+
+    /// Log a warning naming the file and skip it.
+    Warn,
+
+    /// Skip the file without any output.
+    Ignore,
 }
 
 #[derive(Debug, Default)]
@@ -207,6 +244,7 @@ impl Config {
     pub fn to_resolve_config(&self) -> crate::migrate::ResolveConfig {
         let mut config = crate::migrate::ResolveConfig::new();
         config.ignore_chars(self.ignored_chars.iter().copied());
+        config.unrecognized_sql_files(self.unrecognized_sql_files);
         config
     }
 }

--- a/sqlx-core/src/config/reference.toml
+++ b/sqlx-core/src/config/reference.toml
@@ -216,6 +216,20 @@ migrations-dir = "foo/migrations"
 # where it is known as a byte-order mark (BOM): https://en.wikipedia.org/wiki/Byte_order_mark
 ignored-chars = [" ", "\t", "\r", "\n", "\uFEFF"]
 
+# Error on a `.sql` file in the migrations directory whose name does not parse as
+# `<VERSION>_<DESCRIPTION>.sql`. This is the default.
+#
+# Such a file is usually a migration that was named incorrectly, and would otherwise be skipped
+# without any indication that it did not run.
+# unrecognized-sql-files = "error"
+
+# Log a warning and skip the file instead. Use this if you deliberately keep other SQL scripts
+# alongside your migrations.
+unrecognized-sql-files = "warn"
+
+# Skip the file without any output (the behavior before this option existed).
+# unrecognized-sql-files = "ignore"
+
 # Set default options for new migrations.
 [migrate.defaults]
 # Specify reversible migrations by default (for `sqlx migrate create`).

--- a/sqlx-core/src/config/tests.rs
+++ b/sqlx-core/src/config/tests.rs
@@ -111,6 +111,8 @@ fn assert_migrate_config(config: &config::migrate::Config) {
 
     assert_eq!(config.ignored_chars, ignored_chars);
 
+    assert_eq!(config.unrecognized_sql_files, UnrecognizedSqlFiles::Warn);
+
     assert_eq!(
         config.defaults.migration_type,
         DefaultMigrationType::Reversible

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -16,7 +16,8 @@ use std::path::{Path, PathBuf};
 /// `<VERSION>` is a string that can be parsed into `i64` and its value is
 /// greater than zero, and `<DESCRIPTION>` is a string.
 ///
-/// Files that don't match this format are silently ignored.
+/// Files that don't end in `.sql` are silently ignored. A `.sql` file that doesn't match this
+/// format is an error, since it is almost certainly a migration that was named incorrectly.
 ///
 /// You can create a new empty migration script using sqlx-cli:
 /// `sqlx migrate add <DESCRIPTION>`.
@@ -204,6 +205,18 @@ pub fn resolve_blocking_with_config(
         let parts = file_name.splitn(2, '_').collect::<Vec<_>>();
 
         if parts.len() != 2 || !parts[1].ends_with(".sql") {
+            if file_name.ends_with(".sql") {
+                // A `.sql` file that doesn't parse is almost certainly a migration that was
+                // named incorrectly, so erroring is more useful than silently skipping it.
+                return Err(ResolveError {
+                    message: format!(
+                        "error parsing migration filename {file_name:?}; \
+                         expected the format `<VERSION>_<DESCRIPTION>.sql` (e.g. `01_foo.sql`)"
+                    ),
+                    source: None,
+                });
+            }
+
             // not of the format: <VERSION>_<DESCRIPTION>.<REVERSIBLE_DIRECTION>.sql; ignore
             continue;
         }
@@ -295,4 +308,32 @@ fn checksum_with_ignored_chars() {
     let digest_stripped = migration::checksum(&stripped_sql);
 
     assert_eq!(digest_ignored, digest_stripped);
+}
+
+#[test]
+fn resolve_errors_on_sql_file_without_version_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("schema.sql"), "create table foo();").unwrap();
+
+    let error = resolve_blocking(dir.path())
+        .expect_err("expected an error for a `.sql` file with no version prefix");
+
+    assert!(
+        error.to_string().contains("schema.sql"),
+        "error should name the offending file, got: {error}"
+    );
+}
+
+#[test]
+fn resolve_ignores_files_not_ending_in_sql() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("README.md"), "these are the migrations").unwrap();
+    fs::write(dir.path().join(".gitkeep"), "").unwrap();
+    fs::write(dir.path().join("1_foo.sql"), "create table foo();").unwrap();
+
+    let migrations = resolve_blocking(dir.path()).unwrap();
+
+    assert_eq!(migrations.len(), 1);
+    assert_eq!(migrations[0].0.version, 1);
+    assert_eq!(migrations[0].0.description, "foo");
 }

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -1,3 +1,4 @@
+use crate::config::migrate::UnrecognizedSqlFiles;
 use crate::error::BoxDynError;
 use crate::migrate::{migration, Migration, MigrationType};
 use crate::sql_str::{AssertSqlSafe, SqlSafeStr};
@@ -17,7 +18,8 @@ use std::path::{Path, PathBuf};
 /// greater than zero, and `<DESCRIPTION>` is a string.
 ///
 /// Files that don't end in `.sql` are silently ignored. A `.sql` file that doesn't match this
-/// format is an error, since it is almost certainly a migration that was named incorrectly.
+/// format is an error by default, since it is usually a migration that was named incorrectly;
+/// see [`ResolveConfig::unrecognized_sql_files`] to warn or ignore instead.
 ///
 /// You can create a new empty migration script using sqlx-cli:
 /// `sqlx migrate add <DESCRIPTION>`.
@@ -88,6 +90,7 @@ pub struct ResolveError {
 #[derive(Debug, Default)]
 pub struct ResolveConfig {
     ignored_chars: BTreeSet<char>,
+    unrecognized_sql_files: UnrecognizedSqlFiles,
 }
 
 impl ResolveConfig {
@@ -95,6 +98,7 @@ impl ResolveConfig {
     pub fn new() -> Self {
         ResolveConfig {
             ignored_chars: BTreeSet::new(),
+            unrecognized_sql_files: UnrecognizedSqlFiles::default(),
         }
     }
 
@@ -135,6 +139,16 @@ impl ResolveConfig {
     /// **Use at your own risk.**
     pub fn ignore_chars(&mut self, chars: impl IntoIterator<Item = char>) -> &mut Self {
         self.ignored_chars.extend(chars);
+        self
+    }
+
+    /// Set what to do with a `.sql` file whose name does not parse as
+    /// `<VERSION>_<DESCRIPTION>.sql`.
+    ///
+    /// Defaults to [`UnrecognizedSqlFiles::Error`]. Files that don't end in `.sql` are ignored
+    /// regardless of this setting.
+    pub fn unrecognized_sql_files(&mut self, behavior: UnrecognizedSqlFiles) -> &mut Self {
+        self.unrecognized_sql_files = behavior;
         self
     }
 
@@ -205,16 +219,29 @@ pub fn resolve_blocking_with_config(
         let parts = file_name.splitn(2, '_').collect::<Vec<_>>();
 
         if parts.len() != 2 || !parts[1].ends_with(".sql") {
+            // A `.sql` file that doesn't parse is usually a migration that was named
+            // incorrectly, so erroring is more useful than skipping it without a word.
+            // Projects that keep other SQL scripts here can opt out.
             if file_name.ends_with(".sql") {
-                // A `.sql` file that doesn't parse is almost certainly a migration that was
-                // named incorrectly, so erroring is more useful than silently skipping it.
-                return Err(ResolveError {
-                    message: format!(
-                        "error parsing migration filename {file_name:?}; \
-                         expected the format `<VERSION>_<DESCRIPTION>.sql` (e.g. `01_foo.sql`)"
-                    ),
-                    source: None,
-                });
+                match config.unrecognized_sql_files {
+                    UnrecognizedSqlFiles::Error => {
+                        return Err(ResolveError {
+                            message: format!(
+                                "error parsing migration filename {file_name:?}; \
+                                 expected the format `<VERSION>_<DESCRIPTION>.sql` \
+                                 (e.g. `01_foo.sql`)"
+                            ),
+                            source: None,
+                        });
+                    }
+                    UnrecognizedSqlFiles::Warn => {
+                        tracing::warn!(
+                            "skipping {file_name:?}: not of the format \
+                             `<VERSION>_<DESCRIPTION>.sql` (e.g. `01_foo.sql`)"
+                        );
+                    }
+                    UnrecognizedSqlFiles::Ignore => {}
+                }
             }
 
             // not of the format: <VERSION>_<DESCRIPTION>.<REVERSIBLE_DIRECTION>.sql; ignore
@@ -322,6 +349,24 @@ fn resolve_errors_on_sql_file_without_version_prefix() {
         error.to_string().contains("schema.sql"),
         "error should name the offending file, got: {error}"
     );
+}
+
+#[test]
+fn resolve_can_opt_out_of_erroring_on_unparseable_sql_file() {
+    for behavior in [UnrecognizedSqlFiles::Warn, UnrecognizedSqlFiles::Ignore] {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("schema.sql"), "create table foo();").unwrap();
+        fs::write(dir.path().join("1_foo.sql"), "create table foo();").unwrap();
+
+        let mut config = ResolveConfig::new();
+        config.unrecognized_sql_files(behavior);
+
+        let migrations = resolve_blocking_with_config(dir.path(), &config)
+            .unwrap_or_else(|e| panic!("expected {behavior:?} to skip `schema.sql`, got: {e}"));
+
+        assert_eq!(migrations.len(), 1);
+        assert_eq!(migrations[0].0.version, 1);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #4362.

## The bug

`resolve_blocking_with_config()` splits a migration filename on the first `_` and `continue`s if it
doesn't get two parts. A `.sql` file with no underscore — `schema.sql` — is therefore dropped from
the migration set with **no error and no warning**: the migration runner reports success and the
schema never reaches the database.

The failure mode depends on whether the name happens to contain an underscore. `a_schema.sql`
already hard-errors on the version parse; `schema.sql` is silently ignored. That inconsistency is
the surprising part.

## The fix

When a filename fails to parse but ends in `.sql`, return a `ResolveError` naming the offending file
and the expected `<VERSION>_<DESCRIPTION>.sql` format. Files that don't end in `.sql` (`README`,
`.gitkeep`) are still ignored silently, exactly as before — that behaviour is intentional and is
pinned by a second test.

Also updated the `MigrationSource` doc comment, which claimed "Files that don't match this format are
silently ignored" and is no longer accurate for `.sql` files.

## Verification

Fail-before (test present, source fix reverted):

```
running 6 tests
test migrate::source::resolve_errors_on_sql_file_without_version_prefix ... FAILED
test migrate::source::resolve_ignores_files_not_ending_in_sql ... ok
---- migrate::source::resolve_errors_on_sql_file_without_version_prefix stdout ----
thread '...' panicked at sqlx-core/src/migrate/source.rs:307:10:
expected an error for a `.sql` file with no version prefix: []
test result: FAILED. 5 passed; 1 failed
```

Pass-after:

```
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Baseline before any edit was 4 passed / 0 failed — no pre-existing failures.

`cargo test --test migrate-macro --no-default-features --features runtime-tokio,tls-none,macros,migrate,sqlite`
passes, exercising both the `migrate!` compile-time path and the runtime path over the repo's three
fixture migration directories.

`cargo fmt --all -- --check` clean. `cargo clippy -p sqlx-core --all-targets -- -D warnings` clean.

I also swept every `migrations*/` directory in the repo, including examples and sqlx-cli fixtures:
zero files that the new error would reject.

## Is this a breaking change?

Behaviourally, yes — a `.sql` file that previously resolved to nothing now errors. The issue asks for
"an error (or warning)", and the consistency argument is strong since `a_schema.sql` already errors.
If you'd rather this were a `tracing::warn!` for a 0.9.x patch release, say the word and I'll switch
it.

## Deliberately not done

The other option in the issue — actually supporting version-less migrations — is a feature decision
with ordering and checksum implications, not a bug fix, so I left it alone.
