### PR TITLE
bench: add connection and query benchmarks for SQLite, Postgres, MySQL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,6 +378,12 @@ path = "benches/postgres/connection.rs"
 harness = false
 required-features = ["postgres", "runtime-tokio"]
 
+[[bench]]
+name = "mysql-connection"
+path = "benches/mysql/connection.rs"
+harness = false
+required-features = ["mysql-rsa", "runtime-tokio"]
+
 #
 # MySQL
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,6 +366,12 @@ path = "benches/sqlite/describe.rs"
 harness = false
 required-features = ["sqlite"]
 
+[[bench]]
+name = "sqlite-connection"
+path = "benches/sqlite/connection.rs"
+harness = false
+required-features = ["sqlite", "runtime-tokio"]
+
 #
 # MySQL
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,6 +372,12 @@ path = "benches/sqlite/connection.rs"
 harness = false
 required-features = ["sqlite", "runtime-tokio"]
 
+[[bench]]
+name = "postgres-connection"
+path = "benches/postgres/connection.rs"
+harness = false
+required-features = ["postgres", "runtime-tokio"]
+
 #
 # MySQL
 #

--- a/benches/mysql/connection.rs
+++ b/benches/mysql/connection.rs
@@ -54,20 +54,22 @@ async fn do_ping(conn: &RefCell<MySqlConnection>) {
 
 async fn do_query_small(conn: &RefCell<MySqlConnection>) {
     let mut guard = conn.borrow_mut();
-    let _: (i64, String, Vec<u8>, i64, f64) =
+    let row: (i64, String, Vec<u8>, i64, f64) =
         sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data WHERE id = 1")
             .fetch_one(&mut *guard)
             .await
             .unwrap();
+    std::hint::black_box(row);
 }
 
 async fn do_query_large(conn: &RefCell<MySqlConnection>) {
     let mut guard = conn.borrow_mut();
-    let _: Vec<(i64, String, Vec<u8>, i64, f64)> =
+    let rows: Vec<(i64, String, Vec<u8>, i64, f64)> =
         sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data")
             .fetch_all(&mut *guard)
             .await
             .unwrap();
+    std::hint::black_box(rows);
 }
 
 async fn do_pool_checkout(pool: &sqlx::MySqlPool) {
@@ -80,8 +82,21 @@ fn bench_new_connection(c: &mut Criterion) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let url = db_url();
     c.bench_function("new_connection", |b| {
-        b.to_async(&runtime).iter(|| async {
-            drop(MySqlConnection::connect(&url).await.unwrap());
+        // Time only `connect`; close gracefully (sends `COM_QUIT`) outside the
+        // measured section so we don't leave abandoned sockets on the server
+        // across thousands of iterations.
+        b.to_async(&runtime).iter_custom(|iters| {
+            let url = url.as_str();
+            async move {
+                let mut total = std::time::Duration::ZERO;
+                for _ in 0..iters {
+                    let start = std::time::Instant::now();
+                    let conn = MySqlConnection::connect(url).await.unwrap();
+                    total += start.elapsed();
+                    conn.close().await.unwrap();
+                }
+                total
+            }
         });
     });
 }
@@ -93,6 +108,9 @@ fn bench_pool_checkout(c: &mut Criterion) {
             MySqlPoolOptions::new()
                 .min_connections(1)
                 .max_connections(1)
+                // Otherwise every `acquire()` pings the connection first, so this
+                // would measure `ping` rather than the pool checkout fast path.
+                .test_before_acquire(false)
                 .connect(&db_url()),
         )
         .unwrap();

--- a/benches/mysql/connection.rs
+++ b/benches/mysql/connection.rs
@@ -1,0 +1,144 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use sqlx::mysql::{MySqlConnection, MySqlPoolOptions};
+use sqlx::{Connection, Executor};
+use std::cell::RefCell;
+
+const LARGE_RESULT_ROWS: i64 = 10_000;
+
+fn db_url() -> String {
+    dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set")
+}
+
+async fn setup_conn() -> MySqlConnection {
+    let mut conn = MySqlConnection::connect(&db_url()).await.unwrap();
+
+    conn.execute(
+        "CREATE TEMPORARY TABLE bench_data (
+            id    BIGINT       NOT NULL PRIMARY KEY,
+            name  TEXT         NOT NULL,
+            data  BLOB         NOT NULL,
+            val1  BIGINT       NOT NULL,
+            val2  DOUBLE       NOT NULL
+        )",
+    )
+    .await
+    .unwrap();
+
+    // MySQL's recursive CTE default limit is 1000; raise it for this session.
+    conn.execute("SET cte_max_recursion_depth = 10000")
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "INSERT INTO bench_data (id, name, data, val1, val2)
+         WITH RECURSIVE gen(n) AS (
+             SELECT 1
+             UNION ALL
+             SELECT n + 1 FROM gen WHERE n < ?
+         )
+         SELECT n, CONCAT('row_', n), UNHEX(LPAD('', 32, '0')), n, n FROM gen",
+    )
+    .bind(LARGE_RESULT_ROWS)
+    .execute(&mut conn)
+    .await
+    .unwrap();
+
+    conn
+}
+
+// ── async helpers ────────────────────────────────────────────────────────────
+
+async fn do_ping(conn: &RefCell<MySqlConnection>) {
+    conn.borrow_mut().ping().await.unwrap();
+}
+
+async fn do_query_small(conn: &RefCell<MySqlConnection>) {
+    let mut guard = conn.borrow_mut();
+    let _: (i64, String, Vec<u8>, i64, f64) =
+        sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data WHERE id = 1")
+            .fetch_one(&mut *guard)
+            .await
+            .unwrap();
+}
+
+async fn do_query_large(conn: &RefCell<MySqlConnection>) {
+    let mut guard = conn.borrow_mut();
+    let _: Vec<(i64, String, Vec<u8>, i64, f64)> =
+        sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data")
+            .fetch_all(&mut *guard)
+            .await
+            .unwrap();
+}
+
+async fn do_pool_checkout(pool: &sqlx::MySqlPool) {
+    let _conn = pool.acquire().await.unwrap();
+}
+
+// ── criterion functions ───────────────────────────────────────────────────────
+
+fn bench_new_connection(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let url = db_url();
+    c.bench_function("new_connection", |b| {
+        b.to_async(&runtime).iter(|| async {
+            drop(MySqlConnection::connect(&url).await.unwrap());
+        });
+    });
+}
+
+fn bench_pool_checkout(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let pool = runtime
+        .block_on(
+            MySqlPoolOptions::new()
+                .min_connections(1)
+                .max_connections(1)
+                .connect(&db_url()),
+        )
+        .unwrap();
+
+    c.bench_function("pool_checkout", |b| {
+        b.to_async(&runtime).iter(|| do_pool_checkout(&pool));
+    });
+}
+
+fn bench_ping(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let conn = RefCell::new(
+        runtime
+            .block_on(MySqlConnection::connect(&db_url()))
+            .unwrap(),
+    );
+
+    c.bench_function("ping", |b| {
+        b.to_async(&runtime).iter(|| do_ping(&conn));
+    });
+}
+
+fn bench_query_small(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let conn = RefCell::new(runtime.block_on(setup_conn()));
+
+    c.bench_function("query_small_result", |b| {
+        b.to_async(&runtime).iter(|| do_query_small(&conn));
+    });
+}
+
+fn bench_query_large(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let conn = RefCell::new(runtime.block_on(setup_conn()));
+
+    c.bench_function("query_large_result", |b| {
+        b.to_async(&runtime).iter(|| do_query_large(&conn));
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_new_connection,
+    bench_pool_checkout,
+    bench_ping,
+    bench_query_small,
+    bench_query_large,
+);
+criterion_main!(benches);

--- a/benches/mysql/connection.rs
+++ b/benches/mysql/connection.rs
@@ -108,8 +108,12 @@ fn bench_pool_checkout(c: &mut Criterion) {
             MySqlPoolOptions::new()
                 .min_connections(1)
                 .max_connections(1)
-                // Otherwise every `acquire()` pings the connection first, so this
-                // would measure `ping` rather than the pool checkout fast path.
+                // Disable the on-acquire ping (`test_before_acquire` defaults to
+                // `true`); otherwise each iteration pays *two* round-trips: a ping
+                // on acquire and a ping on release. Note the pool still does a
+                // mandatory on-release ping when the guard is dropped, so this
+                // measures a full borrow+return cycle, not a purely in-process
+                // checkout.
                 .test_before_acquire(false)
                 .connect(&db_url()),
         )

--- a/benches/postgres/connection.rs
+++ b/benches/postgres/connection.rs
@@ -100,11 +100,7 @@ fn bench_pool_checkout(c: &mut Criterion) {
 
 fn bench_ping(c: &mut Criterion) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
-    let conn = RefCell::new(
-        runtime
-            .block_on(PgConnection::connect(&db_url()))
-            .unwrap(),
-    );
+    let conn = RefCell::new(runtime.block_on(PgConnection::connect(&db_url())).unwrap());
 
     c.bench_function("ping", |b| {
         b.to_async(&runtime).iter(|| do_ping(&conn));

--- a/benches/postgres/connection.rs
+++ b/benches/postgres/connection.rs
@@ -50,20 +50,22 @@ async fn do_ping(conn: &RefCell<PgConnection>) {
 
 async fn do_query_small(conn: &RefCell<PgConnection>) {
     let mut guard = conn.borrow_mut();
-    let _: (i64, String, Vec<u8>, i64, f64) =
+    let row: (i64, String, Vec<u8>, i64, f64) =
         sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data WHERE id = 1")
             .fetch_one(&mut *guard)
             .await
             .unwrap();
+    std::hint::black_box(row);
 }
 
 async fn do_query_large(conn: &RefCell<PgConnection>) {
     let mut guard = conn.borrow_mut();
-    let _: Vec<(i64, String, Vec<u8>, i64, f64)> =
+    let rows: Vec<(i64, String, Vec<u8>, i64, f64)> =
         sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data")
             .fetch_all(&mut *guard)
             .await
             .unwrap();
+    std::hint::black_box(rows);
 }
 
 async fn do_pool_checkout(pool: &sqlx::PgPool) {
@@ -76,8 +78,21 @@ fn bench_new_connection(c: &mut Criterion) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let url = db_url();
     c.bench_function("new_connection", |b| {
-        b.to_async(&runtime).iter(|| async {
-            drop(PgConnection::connect(&url).await.unwrap());
+        // Time only `connect`; close gracefully (sends `Terminate`) outside the
+        // measured section so we don't leave abandoned sockets on the server
+        // across thousands of iterations.
+        b.to_async(&runtime).iter_custom(|iters| {
+            let url = url.as_str();
+            async move {
+                let mut total = std::time::Duration::ZERO;
+                for _ in 0..iters {
+                    let start = std::time::Instant::now();
+                    let conn = PgConnection::connect(url).await.unwrap();
+                    total += start.elapsed();
+                    conn.close().await.unwrap();
+                }
+                total
+            }
         });
     });
 }
@@ -89,6 +104,9 @@ fn bench_pool_checkout(c: &mut Criterion) {
             PgPoolOptions::new()
                 .min_connections(1)
                 .max_connections(1)
+                // Otherwise every `acquire()` pings the connection first, so this
+                // would measure `ping` rather than the pool checkout fast path.
+                .test_before_acquire(false)
                 .connect(&db_url()),
         )
         .unwrap();

--- a/benches/postgres/connection.rs
+++ b/benches/postgres/connection.rs
@@ -104,8 +104,12 @@ fn bench_pool_checkout(c: &mut Criterion) {
             PgPoolOptions::new()
                 .min_connections(1)
                 .max_connections(1)
-                // Otherwise every `acquire()` pings the connection first, so this
-                // would measure `ping` rather than the pool checkout fast path.
+                // Disable the on-acquire ping (`test_before_acquire` defaults to
+                // `true`); otherwise each iteration pays *two* round-trips: a ping
+                // on acquire and a ping on release. Note the pool still does a
+                // mandatory on-release ping when the guard is dropped, so this
+                // measures a full borrow+return cycle, not a purely in-process
+                // checkout.
                 .test_before_acquire(false)
                 .connect(&db_url()),
         )

--- a/benches/postgres/connection.rs
+++ b/benches/postgres/connection.rs
@@ -1,0 +1,140 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use sqlx::postgres::{PgConnection, PgPoolOptions};
+use sqlx::{Connection, Executor};
+use std::cell::RefCell;
+
+const LARGE_RESULT_ROWS: i64 = 10_000;
+
+fn db_url() -> String {
+    dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set")
+}
+
+async fn setup_conn() -> PgConnection {
+    let mut conn = PgConnection::connect(&db_url()).await.unwrap();
+
+    conn.execute(
+        "CREATE TEMP TABLE bench_data (
+            id    BIGINT  PRIMARY KEY,
+            name  TEXT    NOT NULL,
+            data  BYTEA   NOT NULL,
+            val1  BIGINT  NOT NULL,
+            val2  FLOAT8  NOT NULL
+        )",
+    )
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO bench_data (id, name, data, val1, val2)
+         SELECT
+             n,
+             'row_' || n,
+             decode(lpad('', 32, '0'), 'hex'),
+             n,
+             n::float8
+         FROM generate_series(1, $1) AS n",
+    )
+    .bind(LARGE_RESULT_ROWS)
+    .execute(&mut conn)
+    .await
+    .unwrap();
+
+    conn
+}
+
+// ── async helpers ────────────────────────────────────────────────────────────
+
+async fn do_ping(conn: &RefCell<PgConnection>) {
+    conn.borrow_mut().ping().await.unwrap();
+}
+
+async fn do_query_small(conn: &RefCell<PgConnection>) {
+    let mut guard = conn.borrow_mut();
+    let _: (i64, String, Vec<u8>, i64, f64) =
+        sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data WHERE id = 1")
+            .fetch_one(&mut *guard)
+            .await
+            .unwrap();
+}
+
+async fn do_query_large(conn: &RefCell<PgConnection>) {
+    let mut guard = conn.borrow_mut();
+    let _: Vec<(i64, String, Vec<u8>, i64, f64)> =
+        sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data")
+            .fetch_all(&mut *guard)
+            .await
+            .unwrap();
+}
+
+async fn do_pool_checkout(pool: &sqlx::PgPool) {
+    let _conn = pool.acquire().await.unwrap();
+}
+
+// ── criterion functions ───────────────────────────────────────────────────────
+
+fn bench_new_connection(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let url = db_url();
+    c.bench_function("new_connection", |b| {
+        b.to_async(&runtime).iter(|| async {
+            drop(PgConnection::connect(&url).await.unwrap());
+        });
+    });
+}
+
+fn bench_pool_checkout(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let pool = runtime
+        .block_on(
+            PgPoolOptions::new()
+                .min_connections(1)
+                .max_connections(1)
+                .connect(&db_url()),
+        )
+        .unwrap();
+
+    c.bench_function("pool_checkout", |b| {
+        b.to_async(&runtime).iter(|| do_pool_checkout(&pool));
+    });
+}
+
+fn bench_ping(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let conn = RefCell::new(
+        runtime
+            .block_on(PgConnection::connect(&db_url()))
+            .unwrap(),
+    );
+
+    c.bench_function("ping", |b| {
+        b.to_async(&runtime).iter(|| do_ping(&conn));
+    });
+}
+
+fn bench_query_small(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let conn = RefCell::new(runtime.block_on(setup_conn()));
+
+    c.bench_function("query_small_result", |b| {
+        b.to_async(&runtime).iter(|| do_query_small(&conn));
+    });
+}
+
+fn bench_query_large(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let conn = RefCell::new(runtime.block_on(setup_conn()));
+
+    c.bench_function("query_large_result", |b| {
+        b.to_async(&runtime).iter(|| do_query_large(&conn));
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_new_connection,
+    bench_pool_checkout,
+    bench_ping,
+    bench_query_small,
+    bench_query_large,
+);
+criterion_main!(benches);

--- a/benches/sqlite/connection.rs
+++ b/benches/sqlite/connection.rs
@@ -96,8 +96,12 @@ fn bench_pool_checkout(c: &mut Criterion) {
             SqlitePoolOptions::new()
                 .min_connections(1)
                 .max_connections(1)
-                // Otherwise every `acquire()` pings the connection first, so this
-                // would measure `ping` rather than the pool checkout fast path.
+                // Disable the on-acquire ping (`test_before_acquire` defaults to
+                // `true`); otherwise each iteration pays *two* round-trips: a ping
+                // on acquire and a ping on release. Note the pool still does a
+                // mandatory on-release ping when the guard is dropped, so this
+                // measures a full borrow+return cycle, not a purely in-process
+                // checkout.
                 .test_before_acquire(false)
                 .connect(DB_URL),
         )

--- a/benches/sqlite/connection.rs
+++ b/benches/sqlite/connection.rs
@@ -47,20 +47,22 @@ async fn do_ping(conn: &RefCell<SqliteConnection>) {
 
 async fn do_query_small(conn: &RefCell<SqliteConnection>) {
     let mut guard = conn.borrow_mut();
-    let _: (i64, String, Vec<u8>, i64, f64) =
+    let row: (i64, String, Vec<u8>, i64, f64) =
         sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data WHERE id = 1")
             .fetch_one(&mut *guard)
             .await
             .unwrap();
+    std::hint::black_box(row);
 }
 
 async fn do_query_large(conn: &RefCell<SqliteConnection>) {
     let mut guard = conn.borrow_mut();
-    let _: Vec<(i64, String, Vec<u8>, i64, f64)> =
+    let rows: Vec<(i64, String, Vec<u8>, i64, f64)> =
         sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data")
             .fetch_all(&mut *guard)
             .await
             .unwrap();
+    std::hint::black_box(rows);
 }
 
 async fn do_pool_checkout(pool: &sqlx::SqlitePool) {
@@ -72,8 +74,17 @@ async fn do_pool_checkout(pool: &sqlx::SqlitePool) {
 fn bench_new_connection(c: &mut Criterion) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
     c.bench_function("new_connection", |b| {
-        b.to_async(&runtime).iter(|| async {
-            drop(SqliteConnection::connect(DB_URL).await.unwrap());
+        // Time only `connect`; close gracefully outside the measured section so we
+        // don't abandon sockets/handles across thousands of iterations.
+        b.to_async(&runtime).iter_custom(|iters| async move {
+            let mut total = std::time::Duration::ZERO;
+            for _ in 0..iters {
+                let start = std::time::Instant::now();
+                let conn = SqliteConnection::connect(DB_URL).await.unwrap();
+                total += start.elapsed();
+                conn.close().await.unwrap();
+            }
+            total
         });
     });
 }
@@ -85,6 +96,9 @@ fn bench_pool_checkout(c: &mut Criterion) {
             SqlitePoolOptions::new()
                 .min_connections(1)
                 .max_connections(1)
+                // Otherwise every `acquire()` pings the connection first, so this
+                // would measure `ping` rather than the pool checkout fast path.
+                .test_before_acquire(false)
                 .connect(DB_URL),
         )
         .unwrap();

--- a/benches/sqlite/connection.rs
+++ b/benches/sqlite/connection.rs
@@ -1,0 +1,136 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use sqlx::sqlite::{SqliteConnection, SqlitePoolOptions};
+use sqlx::{Connection, Executor};
+use std::cell::RefCell;
+
+const DB_URL: &str = "sqlite::memory:";
+const LARGE_RESULT_ROWS: i64 = 10_000;
+
+async fn setup_conn() -> SqliteConnection {
+    let mut conn = SqliteConnection::connect(DB_URL).await.unwrap();
+
+    conn.execute(
+        "CREATE TEMP TABLE bench_data (
+            id    INTEGER PRIMARY KEY,
+            name  TEXT    NOT NULL,
+            data  BLOB    NOT NULL,
+            val1  INTEGER NOT NULL,
+            val2  REAL    NOT NULL
+        )",
+    )
+    .await
+    .unwrap();
+
+    // Populate with LARGE_RESULT_ROWS rows using a recursive CTE.
+    sqlx::query(
+        "INSERT INTO bench_data (id, name, data, val1, val2)
+         WITH RECURSIVE gen(n) AS (
+             VALUES(1)
+             UNION ALL
+             SELECT n + 1 FROM gen WHERE n < ?
+         )
+         SELECT n, 'row_' || n, zeroblob(16), n, CAST(n AS REAL) FROM gen",
+    )
+    .bind(LARGE_RESULT_ROWS)
+    .execute(&mut conn)
+    .await
+    .unwrap();
+
+    conn
+}
+
+// ── async helpers ────────────────────────────────────────────────────────────
+
+async fn do_ping(conn: &RefCell<SqliteConnection>) {
+    conn.borrow_mut().ping().await.unwrap();
+}
+
+async fn do_query_small(conn: &RefCell<SqliteConnection>) {
+    let mut guard = conn.borrow_mut();
+    let _: (i64, String, Vec<u8>, i64, f64) =
+        sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data WHERE id = 1")
+            .fetch_one(&mut *guard)
+            .await
+            .unwrap();
+}
+
+async fn do_query_large(conn: &RefCell<SqliteConnection>) {
+    let mut guard = conn.borrow_mut();
+    let _: Vec<(i64, String, Vec<u8>, i64, f64)> =
+        sqlx::query_as("SELECT id, name, data, val1, val2 FROM bench_data")
+            .fetch_all(&mut *guard)
+            .await
+            .unwrap();
+}
+
+async fn do_pool_checkout(pool: &sqlx::SqlitePool) {
+    let _conn = pool.acquire().await.unwrap();
+}
+
+// ── criterion functions ───────────────────────────────────────────────────────
+
+fn bench_new_connection(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    c.bench_function("new_connection", |b| {
+        b.to_async(&runtime).iter(|| async {
+            drop(SqliteConnection::connect(DB_URL).await.unwrap());
+        });
+    });
+}
+
+fn bench_pool_checkout(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let pool = runtime
+        .block_on(
+            SqlitePoolOptions::new()
+                .min_connections(1)
+                .max_connections(1)
+                .connect(DB_URL),
+        )
+        .unwrap();
+
+    c.bench_function("pool_checkout", |b| {
+        b.to_async(&runtime).iter(|| do_pool_checkout(&pool));
+    });
+}
+
+fn bench_ping(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let conn = RefCell::new(
+        runtime
+            .block_on(SqliteConnection::connect(DB_URL))
+            .unwrap(),
+    );
+
+    c.bench_function("ping", |b| {
+        b.to_async(&runtime).iter(|| do_ping(&conn));
+    });
+}
+
+fn bench_query_small(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let conn = RefCell::new(runtime.block_on(setup_conn()));
+
+    c.bench_function("query_small_result", |b| {
+        b.to_async(&runtime).iter(|| do_query_small(&conn));
+    });
+}
+
+fn bench_query_large(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let conn = RefCell::new(runtime.block_on(setup_conn()));
+
+    c.bench_function("query_large_result", |b| {
+        b.to_async(&runtime).iter(|| do_query_large(&conn));
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_new_connection,
+    bench_pool_checkout,
+    bench_ping,
+    bench_query_small,
+    bench_query_large,
+);
+criterion_main!(benches);

--- a/benches/sqlite/connection.rs
+++ b/benches/sqlite/connection.rs
@@ -96,11 +96,7 @@ fn bench_pool_checkout(c: &mut Criterion) {
 
 fn bench_ping(c: &mut Criterion) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
-    let conn = RefCell::new(
-        runtime
-            .block_on(SqliteConnection::connect(DB_URL))
-            .unwrap(),
-    );
+    let conn = RefCell::new(runtime.block_on(SqliteConnection::connect(DB_URL)).unwrap());
 
     c.bench_function("ping", |b| {
         b.to_async(&runtime).iter(|| do_ping(&conn));


### PR DESCRIPTION
Closes #158.

Adds criterion benchmarks covering all items from the issue checklist, for all three supported databases.

## What's included

Each database gets a `benches/<db>/connection.rs` with five benchmarks:

| Benchmark | Description |
|---|---|
| `new_connection` | Establish a fresh connection from scratch (connect only; graceful close is done outside the timed section) |
| `pool_checkout` | Borrow + return a connection from a pool (min=max=1, `test_before_acquire(false)`) |
| `ping` | Ping an existing open connection |
| `query_small_result` | Fetch 1 row by PK from a populated table (TechEmpower single-query style) |
| `query_large_result` | Fetch 10 000 rows with TEXT and BLOB/BYTEA columns |

## How to run

**SQLite** (no external DB needed):
```
cargo bench --bench sqlite-connection --features sqlite,runtime-tokio
```

**Postgres:**
```
DATABASE_URL=postgres://... cargo bench --bench postgres-connection --features postgres,runtime-tokio
```

**MySQL** (`mysql-rsa` enables `caching_sha2_password` auth without TLS for MySQL 8+):
```
DATABASE_URL=mysql://... cargo bench --bench mysql-connection --features mysql-rsa,runtime-tokio
```

The existing `tests/docker-compose.yml` can be used to spin up Postgres and MySQL.

## Example results

Local run (Docker `postgres:17` / `mysql:8.0` over loopback, SQLite `:memory:`; median of criterion's estimate). Absolute numbers are hardware/loopback-specific — they're here to show the benchmarks work and that the metrics are distinct, not as a cross-machine reference.

| Benchmark | SQLite | Postgres | MySQL |
|---|---|---|---|
| `new_connection` | 289 µs | 8.41 ms | 2.15 ms |
| `pool_checkout` | 39.3 µs | 184 µs | 207 µs |
| `ping` | 17.8 µs | 143 µs | 172 µs |
| `query_small_result` | 17.9 µs | 185 µs | 432 µs |
| `query_large_result` | 39.3 ms | 8.42 ms | 10.3 ms |

## Notes on methodology

- **`pool_checkout` measures a full borrow + return cycle**, with the pool's on-acquire ping disabled via `test_before_acquire(false)`. With the default (`true`), each iteration would pay *two* network round-trips: a ping on `acquire()` and a ping on release. Note the pool *always* pings on release (`return_to_pool`) to flush time-sensitive state, and that isn't configurable — so for Postgres/MySQL this benchmark inherently includes one RTT and lands near `ping`. The delta over `ping` (e.g. Postgres 184 µs vs 143 µs) is the pool's own machinery.
- **`new_connection` times `connect()` only.** Connections are closed gracefully (`Terminate` / `COM_QUIT`) *outside* the measured section via `iter_custom`, so teardown isn't included in the timing and we don't abandon thousands of sockets on the server over a run.
- **Fetched results are passed through `std::hint::black_box`** so the optimizer can't elide the decode/allocation work being measured.
- **SQLite numbers aren't directly comparable to Postgres/MySQL.** `sqlite::memory:` has no network round-trip, so its `new_connection`/`ping`/`pool_checkout` measure in-process setup rather than a real connection/RTT. (It's also why SQLite's `query_large_result` looks slow relative to the networked DBs: it's doing the full 10 000-row materialization with no pipelining to overlap, and the tuple decode dominates.) The three DBs share the same schema (16-byte blob, 10 000 rows) but should be read per-database.
