### PR TITLE
feat(pool): add connect_timeout option for spawned connection tasks

### DIFF
--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -289,7 +289,37 @@ impl<DB: Database> PoolInner<DB> {
                     };
 
                     // Attempt to connect...
-                    return self.connect(deadline, guard).await;
+                    //
+                    // If `connect_timeout` is set, spawn the connection as a separate task
+                    // so that cancellation of `acquire()` doesn't abort the connection attempt.
+                    // If the connection succeeds but no one picks it up, it's returned to the pool.
+                    if let Some(connect_timeout) = self.options.connect_timeout {
+                        let connect_deadline = acquire_started_at + self.options.acquire_timeout + connect_timeout;
+                        let pool = (*self).clone();
+
+                        let (tx, rx) = futures_intrusive::channel::oneshot_channel();
+
+                        crate::rt::spawn(async move {
+                            let result = pool.connect(connect_deadline, guard).await;
+
+                            // If `acquire()` is still waiting, send the result.
+                            // If `acquire()` was cancelled (rx dropped), send() will fail
+                            // and we return the connection to the pool.
+                            match tx.send(result) {
+                                Ok(()) => {}
+                                Err(result) => {
+                                    // acquire() was cancelled, return connection to idle queue
+                                    if let Ok(live) = result {
+                                        pool.release(live);
+                                    }
+                                }
+                            }
+                        });
+
+                        return rx.receive().await.map_err(|_| Error::PoolTimedOut)?;
+                    } else {
+                        return self.connect(deadline, guard).await;
+                    }
                 }
             }
         )

--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -297,7 +297,7 @@ impl<DB: Database> PoolInner<DB> {
                         let connect_deadline = acquire_started_at + self.options.acquire_timeout + connect_timeout;
                         let pool = (*self).clone();
 
-                        let (tx, rx) = futures_intrusive::channel::oneshot_channel();
+                        let (tx, rx) = futures_intrusive::channel::shared::oneshot_channel();
 
                         crate::rt::spawn(async move {
                             let result = pool.connect(connect_deadline, guard).await;
@@ -307,7 +307,7 @@ impl<DB: Database> PoolInner<DB> {
                             // and we return the connection to the pool.
                             match tx.send(result) {
                                 Ok(()) => {}
-                                Err(result) => {
+                                Err(futures_intrusive::channel::ChannelSendError(result)) => {
                                     // acquire() was cancelled, return connection to idle queue
                                     if let Ok(live) = result {
                                         pool.release(live);
@@ -316,7 +316,7 @@ impl<DB: Database> PoolInner<DB> {
                             }
                         });
 
-                        return rx.receive().await.map_err(|_| Error::PoolTimedOut)?;
+                        return rx.receive().await.ok_or(Error::PoolTimedOut)?;
                     } else {
                         return self.connect(deadline, guard).await;
                     }

--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -83,6 +83,7 @@ pub struct PoolOptions<DB: Database> {
     pub(crate) max_lifetime: Option<Duration>,
     pub(crate) idle_timeout: Option<Duration>,
     pub(crate) fair: bool,
+    pub(crate) connect_timeout: Option<Duration>,
 
     pub(crate) parent_pool: Option<Pool<DB>>,
 }
@@ -106,6 +107,7 @@ impl<DB: Database> Clone for PoolOptions<DB> {
             max_lifetime: self.max_lifetime,
             idle_timeout: self.idle_timeout,
             fair: self.fair,
+            connect_timeout: self.connect_timeout,
             parent_pool: self.parent_pool.clone(),
         }
     }
@@ -161,6 +163,7 @@ impl<DB: Database> PoolOptions<DB> {
             idle_timeout: Some(Duration::from_secs(10 * 60)),
             max_lifetime: Some(Duration::from_secs(30 * 60)),
             fair: true,
+            connect_timeout: None,
             parent_pool: None,
         }
     }
@@ -305,6 +308,30 @@ impl<DB: Database> PoolOptions<DB> {
     /// Get the maximum idle duration for individual connections.
     pub fn get_idle_timeout(&self) -> Option<Duration> {
         self.idle_timeout
+    }
+
+    /// Set a separate timeout for establishing new connections.
+    ///
+    /// When set, this timeout is used specifically for the connection establishment phase
+    /// of [`Pool::acquire()`], separate from [`acquire_timeout`][Self::acquire_timeout].
+    /// This allows the connection to have its own timeout that doesn't share the budget
+    /// with semaphore acquisition and idle connection checks.
+    ///
+    /// If not set, the connection establishment uses the remaining time from `acquire_timeout`.
+    ///
+    /// This is useful when:
+    /// * You want a longer timeout for establishing connections than for acquiring from the pool.
+    /// * You want connection attempts to survive cancellation of the `acquire()` future.
+    ///   When `acquire()` is cancelled, the spawned connection task continues in the background.
+    ///   If it succeeds, the connection is returned to the pool's idle queue.
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = Some(timeout);
+        self
+    }
+
+    /// Get the connect timeout, if set.
+    pub fn get_connect_timeout(&self) -> Option<Duration> {
+        self.connect_timeout
     }
 
     /// If true, the health of a connection will be verified by a call to [`Connection::ping`]
@@ -587,9 +614,10 @@ impl<DB: Database> Debug for PoolOptions<DB> {
         f.debug_struct("PoolOptions")
             .field("max_connections", &self.max_connections)
             .field("min_connections", &self.min_connections)
-            .field("connect_timeout", &self.acquire_timeout)
+            .field("acquire_timeout", &self.acquire_timeout)
             .field("max_lifetime", &self.max_lifetime)
             .field("idle_timeout", &self.idle_timeout)
+            .field("connect_timeout", &self.connect_timeout)
             .field("test_before_acquire", &self.test_before_acquire)
             .finish()
     }


### PR DESCRIPTION
## Description

This PR adds a new `connect_timeout` option to `PoolOptions` that, when set, spawns the connection attempt as a separate task in `Pool::acquire()`. This ensures that if `acquire()` is cancelled or times out, the connection attempt continues in the background rather than being aborted.

If the connection succeeds but no one picks it up (because `acquire()` was cancelled), the connection is automatically returned to the pool's idle queue.

## Problem

Currently, `acquire()` wraps both the semaphore/idle-connection check and the actual connection creation in a single timeout. If `acquire()` is cancelled (e.g., due to its own timeout), the in-flight `connect()` call is also aborted. Under high contention, this can cause:

- Connection churn: connections are created and immediately discarded
- Pool instability: `DecrementSizeGuard` drops, pool size fluctuates
- Cascading timeouts: other waiting tasks also time out

This is the root cause behind several reported issues: #3315, #3132, #2848.

## Solution

When `connect_timeout` is set on `PoolOptions`:

1. The connection attempt is spawned as a separate async task via `crate::rt::spawn`
2. The spawned task uses its own deadline based on `connect_timeout`
3. A `futures_intrusive::channel::oneshot` channel communicates the result back
4. If `acquire()` is cancelled (receiver dropped), the sender detects this and returns the connection to the pool's idle queue

When `connect_timeout` is **not** set (the default), the existing behavior is preserved exactly -- no breaking changes.

## Changes

- **`sqlx-core/src/pool/options.rs`**: Added `connect_timeout: Option<Duration>` field, builder method, getter, and updated `Debug`/`Clone` impls
- **`sqlx-core/src/pool/inner.rs`**: Modified `acquire()` to spawn connection as a separate task when `connect_timeout` is set

## Usage

```rust
use sqlx::postgres::PgPoolOptions;
use std::time::Duration;

let pool = PgPoolOptions::new()
    .max_connections(10)
    .acquire_timeout(Duration::from_secs(5))
    .connect_timeout(Duration::from_secs(10))  // NEW
    .connect("postgres://localhost/mydb")
    .await?;
```

## Notes

- Uses `futures_intrusive::channel::oneshot_channel` for cross-runtime compatibility (works with tokio, async-std, smol)
- No new dependencies added
- Not a breaking change -- opt-in via new optional field
- Default behavior unchanged when `connect_timeout` is not set

Closes #3513
