### PR TITLE
fix(sqlite): don't dereference a NULL declared type in column_nullable

### DIFF
--- a/sqlx-sqlite/src/statement/handle.rs
+++ b/sqlx-sqlite/src/statement/handle.rs
@@ -263,19 +263,20 @@ impl StatementHandle {
                 return Err(SqliteError::new(self.db_handle()).into());
             }
 
-            let datatype = CStr::from_ptr(datatype);
+            // `sqlite3_table_column_metadata()` sets the declared type to NULL for a column
+            // declared without one, e.g. `CREATE TABLE foo (bar PRIMARY KEY)`. Such a column
+            // has no type name to compare against, and is by definition not declared
+            // `INTEGER`, so it cannot be a rowid alias.
+            let is_integer = !datatype.is_null()
+                && CStr::from_ptr(datatype)
+                    .to_bytes()
+                    .eq_ignore_ascii_case("integer".as_bytes());
 
-            Ok(
-                if primary_key != 0
-                    && datatype
-                        .to_bytes()
-                        .eq_ignore_ascii_case("integer".as_bytes())
-                {
-                    None
-                } else {
-                    Some(not_null == 0)
-                },
-            )
+            Ok(if primary_key != 0 && is_integer {
+                None
+            } else {
+                Some(not_null == 0)
+            })
         }
     }
 

--- a/sqlx-sqlite/src/statement/handle.rs
+++ b/sqlx-sqlite/src/statement/handle.rs
@@ -267,12 +267,13 @@ impl StatementHandle {
             // declared without one, e.g. `CREATE TABLE foo (bar PRIMARY KEY)`. Such a column
             // has no type name to compare against, and is by definition not declared
             // `INTEGER`, so it cannot be a rowid alias.
-            let is_integer = !datatype.is_null()
+            let is_rowid_alias = primary_key != 0
+                && !datatype.is_null()
                 && CStr::from_ptr(datatype)
                     .to_bytes()
                     .eq_ignore_ascii_case("integer".as_bytes());
 
-            Ok(if primary_key != 0 && is_integer {
+            Ok(if is_rowid_alias {
                 None
             } else {
                 Some(not_null == 0)

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -2,7 +2,7 @@ use sqlx::error::DatabaseError;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteError};
 use sqlx::TypeInfo;
 use sqlx::{sqlite::Sqlite, Column, Executor};
-use sqlx::{ConnectOptions, SqlSafeStr};
+use sqlx::{ConnectOptions, Connection, SqlSafeStr, SqliteConnection};
 use sqlx_test::new;
 use std::env;
 
@@ -1092,6 +1092,39 @@ async fn it_describes_analytical_function() -> anyhow::Result<()> {
         .await?;
     assert_eq!(d.column(0).type_info().name(), "TEXT");
     assert_eq!(d.nullable(0), Some(true));
+
+    Ok(())
+}
+
+// A column declared with no type at all, e.g. `CREATE TABLE foo (bar PRIMARY KEY)`, is
+// legal SQLite. `sqlite3_table_column_metadata()` reports a NULL declared type for such a
+// column, which `column_nullable()` used to dereference unconditionally, segfaulting the
+// process, and thus rustc itself when the `query!()` macros describe a live database.
+#[sqlx_macros::test]
+async fn it_describes_columns_with_no_declared_type() -> anyhow::Result<()> {
+    let mut conn = SqliteConnection::connect(":memory:").await?;
+
+    conn.execute(
+        r#"
+        CREATE TABLE untyped (
+            id PRIMARY KEY,
+            typeless,
+            typed TEXT NOT NULL
+        );
+        "#
+        .into_sql_str(),
+    )
+    .await?;
+
+    let d = conn
+        .describe("SELECT id, typeless, typed FROM untyped".into_sql_str())
+        .await?;
+
+    // A `PRIMARY KEY` with no declared type is not an `INTEGER PRIMARY KEY`, so it is not a
+    // rowid alias and SQLite does permit NULLs in it.
+    assert_eq!(d.nullable(0), Some(true));
+    assert_eq!(d.nullable(1), Some(true));
+    assert_eq!(d.nullable(2), Some(false));
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #4373 

`sqlite3_table_column_metadata()` leaves its declared-type out-param NULL when a column was declared with no type (`CREATE TABLE foo (bar PRIMARY KEY)` is legal SQLite). `column_nullable()` passed that pointer straight into `CStr::from_ptr()`, so describing such a column segfaulted. Since `query!()` describes a live database while expanding, the process that died was `rustc`.

Introduced in 69ee0df (#4088), released in 0.9.0. Before that the slot was `ptr::null_mut()` and never read.

**The fix.** Only read the pointer when it's non-null. A column with no declared type isn't declared `INTEGER`, so it can't be a rowid alias, and it falls through to the ordinary `NOT NULL` check:

```rust
let is_integer = !datatype.is_null()
    && CStr::from_ptr(datatype)
        .to_bytes()
        .eq_ignore_ascii_case("integer".as_bytes());

Ok(if primary_key != 0 && is_integer {
    None
} else {
    Some(not_null == 0)
})
```

This matches what `column_decltype()` right above already does with the pointer from `sqlite3_column_decltype()`.

That's also the correct answer semantically, not just a crash guard: a `PRIMARY KEY` with no declared type has BLOB affinity, is not a rowid alias, and SQLite really does allow NULLs in it, so `Some(true)` is right.

**After the fix**, an untyped column gives the normal diagnostic instead of a crash:

```
error: no built-in mapping found for type NULL of column #1 ("device_id");
       a type override may be required
```

and a type override (`device_id as "device_id!: String"`) compiles cleanly. That's the behaviour #1979 and #3546 describe.