### PR TITLE
fix(postgres): mark the null-extended side of every outer join

### DIFF
--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -133,7 +133,7 @@ impl PgConnection {
 
     /// Infer nullability for columns of this statement using EXPLAIN VERBOSE.
     ///
-    /// This currently only marks columns that are on the inner half of an outer join
+    /// This currently only marks columns that an outer join can set to `NULL`
     /// and returns `None` for all others.
     async fn nullables_from_explain(
         &mut self,
@@ -177,20 +177,28 @@ impl PgConnection {
         }) = explains.first()
         {
             nullables.resize(outputs.len(), None);
-            visit_plan(plan, outputs, &mut nullables);
+            visit_plan(plan, outputs, &mut nullables, false);
         }
 
         Ok(nullables)
     }
 }
 
-fn visit_plan(plan: &Plan, outputs: &[String], nullables: &mut Vec<Option<bool>>) {
-    if let Some(plan_outputs) = &plan.output {
-        // all outputs of a Full Join must be marked nullable
-        // otherwise, all outputs of the inner half of an outer join must be marked nullable
-        if plan.join_type.as_deref() == Some("Full")
-            || plan.parent_relation.as_deref() == Some("Inner")
-        {
+/// Mark every output of this plan that an outer join can set to `NULL`.
+///
+/// `null_extended` is true when this plan is the null-extended input of an outer join above it.
+/// `visit_plan` visits every child, because a join can sit below any node, such as `Limit`.
+fn visit_plan(
+    plan: &Plan,
+    outputs: &[String],
+    nullables: &mut Vec<Option<bool>>,
+    null_extended: bool,
+) {
+    // all outputs of a Full Join must be marked nullable
+    let null_extended = null_extended || plan.join_type.as_deref() == Some("Full");
+
+    if null_extended {
+        if let Some(plan_outputs) = &plan.output {
             for output in plan_outputs {
                 if let Some(i) = outputs.iter().position(|o| o == output) {
                     // N.B. this may produce false positives but those don't cause runtime errors
@@ -201,10 +209,17 @@ fn visit_plan(plan: &Plan, outputs: &[String], nullables: &mut Vec<Option<bool>>
     }
 
     if let Some(plans) = &plan.plans {
-        if let Some("Left") | Some("Right") = plan.join_type.as_deref() {
-            for plan in plans {
-                visit_plan(plan, outputs, nullables);
-            }
+        for child in plans {
+            let child_null_extended = match plan.join_type.as_deref() {
+                // PostgreSQL defines `JOIN_RIGHT` as the mirror of `JOIN_LEFT`, so the
+                // null-extended input is the Inner child of a Left join and the Outer
+                // child of a Right join. See <https://github.com/launchbadge/sqlx/issues/367>.
+                Some("Left") => child.parent_relation.as_deref() == Some("Inner"),
+                Some("Right") => child.parent_relation.as_deref() == Some("Outer"),
+                _ => false,
+            };
+
+            visit_plan(child, outputs, nullables, child_null_extended);
         }
     }
 }

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -1032,6 +1032,68 @@ from (values (null)) vals(val)
     assert_eq!(describe.nullable(0), Some(true));
     assert_eq!(describe.nullable(1), Some(true));
 
+    // a left join the planner commutes into a `Join Type: Right` node
+    // language=PostgreSQL
+    let describe = conn
+        .describe(
+            "select tweet.text, tweet_reply.text
+    from tweet
+    left join tweet_reply on tweet_reply.tweet_id = tweet.id"
+                .into_sql_str(),
+        )
+        .await?;
+
+    // tweet.text is on the preserved half, so it must stay NOT NULL
+    assert_eq!(describe.nullable(0), Some(false));
+    assert_eq!(describe.nullable(1), Some(true));
+
+    // two chained left joins, which nest two `Right` nodes
+    // language=PostgreSQL
+    let describe = conn
+        .describe(
+            "select tweet.text, reply1.text, reply2.text
+    from tweet
+    left join tweet_reply reply1 on reply1.tweet_id = tweet.id
+    left join tweet_reply reply2 on reply2.tweet_id = tweet.id"
+                .into_sql_str(),
+        )
+        .await?;
+
+    assert_eq!(describe.nullable(0), Some(false));
+    assert_eq!(describe.nullable(1), Some(true));
+    assert_eq!(describe.nullable(2), Some(true));
+
+    // a join below a node that is not a join
+    // language=PostgreSQL
+    let describe = conn
+        .describe(
+            "select tweet.text, tweet_reply.text
+    from tweet
+    left join tweet_reply on tweet_reply.tweet_id = tweet.id
+    limit 5"
+                .into_sql_str(),
+        )
+        .await?;
+
+    assert_eq!(describe.nullable(0), Some(false));
+    assert_eq!(describe.nullable(1), Some(true));
+
+    // the same query with `order by`. The planner gives it the opposite join type from the
+    // `limit` case, so the two cases together cover a `Left` node and a `Right` node.
+    // language=PostgreSQL
+    let describe = conn
+        .describe(
+            "select tweet.text, tweet_reply.text
+    from tweet
+    left join tweet_reply on tweet_reply.tweet_id = tweet.id
+    order by tweet.id"
+                .into_sql_str(),
+        )
+        .await?;
+
+    assert_eq!(describe.nullable(0), Some(false));
+    assert_eq!(describe.nullable(1), Some(true));
+
     Ok(())
 }
 


### PR DESCRIPTION
### Does your PR solve an issue?

fixes #367

### Is this a breaking change?

Yes. For a column brought in by an outer join, the generated type can widen
from `T` to `Option<T>`, and it can also narrow from `Option<T>` to `T`.

A column on the null-extended side widens to `Option<T>`. As in #566, few
callers should break. Such a column raises `UnexpectedNull` at runtime today,
unless the query already overrides the column with `foo as "foo?"`.

A column on the preserved side narrows to `T`. Code that matches on the
`Option` must drop the match, or override the column with `foo as "foo!"`.

### Problem

`visit_plan` has two faults.

**First**, it marks the wrong child of a `Right` join node. The planner often
turns a plain `LEFT JOIN` into such a node, so PostgreSQL and sqlx disagree
about which column is nullable:

```sql
create table tweet       (id bigint primary key, text text not null);
create table tweet_reply (id bigint primary key, tweet_id bigint not null,
                          text text not null);
insert into tweet values (1, 'hello');

select tweet.text, tweet_reply.text
  from tweet left join tweet_reply on tweet_reply.tweet_id = tweet.id;

 text  | text
-------+------
 hello |          -- tweet_reply.text is NULL
```

PostgreSQL returns `NULL` for `tweet_reply.text`. sqlx reports
`nullable: [true, false]`, which says that `tweet.text` is the nullable column
and that `tweet_reply.text` cannot be `NULL`. Both answers are wrong.

The plan shows why. The planner commuted the `LEFT JOIN` into a `Right` join
node:

```
Hash Join  | Join Type: Right           | Output: [tweet.text, tweet_reply.text]
  Seq Scan | Parent Relationship: Outer | Output: [tweet_reply.id, ..., tweet_reply.text]
  Hash     | Parent Relationship: Inner | Output: [tweet.text, tweet.id]
```

`visit_plan` marks the child that carries `Parent Relationship: Inner`, which is
the `Hash` node over `tweet`. Under `Join Type: Right` that child is the
preserved side, and the `Outer` child is the null-extended side.

`Parent Relationship` gives a child's position, not the preserved side.
`ExplainNode` labels the left child `Outer` and the right child `Inner` for
every node type. `Join Type` is what names the preserved side.

**Second fault**: `visit_plan` descends only through join nodes. A `Limit`, a
`Sort`, an `Aggregate`, or a plain inner join above an outer join ends the walk,
and no column is marked at all. This fault also applies to a `Left` join node, so
`select t.text, r.text from tweet t left join tweet_reply r on ... limit 5`
reports both columns as `NOT NULL`.

### Fix

`visit_plan` now passes a `null_extended` flag to the null-extended input of
each outer join, and visits every child.

### Testing

I added four cases to `test_describe_outer_join_nullable`, and each one fails
before the fix. Every case asserts the preserved side as well as the
null-extended side. The `limit` case and the `order by` case are the same query,
and the planner gives them opposite join types, so the pair covers a `Left` node
and a `Right` node. CI covers PostgreSQL 13 and 17. I also ran 14, 15, 16 and 18
locally.

I also checked both repros from #367. On the schema in the original report,
`describe` now marks `c2.color_uuid` as nullable, which removes the
`UnexpectedNullError` that report shows, and it stops marking the preserved
`o.object_uuid` as nullable. On the repro in the most recent comment,
`describe` now reports `[false, true]` instead of `[true, false]`.
