### PR TITLE
fix(postgres): roll back a transaction cancelled during BEGIN

### DIFF
--- a/sqlx-postgres/src/transaction.rs
+++ b/sqlx-postgres/src/transaction.rs
@@ -27,11 +27,18 @@ impl TransactionManager for PgTransactionManager {
 
         let rollback = Rollback::new(conn);
         rollback.conn.queue_simple_query(statement.as_str())?;
+        // Claim the depth before the round trip, not after. `start_rollback` -- which both
+        // this guard and `Transaction`'s own drop guard call -- is a no-op while the depth is
+        // zero, so a future cancelled during the await below would otherwise leave the server
+        // in a transaction with nothing queued to end it. `Pool` then hands that connection
+        // to the next borrower, whose statements silently run inside it. Unwound just below
+        // if the BEGIN did not take.
+        rollback.conn.inner.transaction_depth += 1;
         rollback.conn.wait_until_ready().await?;
         if !rollback.conn.in_transaction() {
+            rollback.conn.inner.transaction_depth -= 1;
             return Err(Error::BeginFailed);
         }
-        rollback.conn.inner.transaction_depth += 1;
         rollback.defuse();
 
         Ok(())

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -2244,3 +2244,54 @@ async fn it_can_recover_from_copy_in_invalid_params() -> anyhow::Result<()> {
     )
     .await
 }
+
+// Regression: a future cancelled while `BEGIN`'s round trip is in flight used to leave the
+// session inside a transaction. `start_rollback` is a no-op while `transaction_depth` is
+// zero, and the depth was raised only after the await, so neither drop guard queued a
+// `ROLLBACK` -- and `return_to_pool` validates with a bare `wait_until_ready` that never
+// looks at the `ReadyForQuery` transaction-status byte, so the connection was handed to the
+// next borrower with the transaction still open.
+#[sqlx_macros::test]
+async fn it_rolls_back_a_transaction_cancelled_during_begin() -> anyhow::Result<()> {
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .min_connections(0)
+        .connect(&dotenvy::var("DATABASE_URL")?)
+        .await?;
+
+    let pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&pool)
+        .await?;
+
+    // A plain `BEGIN` answers too quickly to cancel reliably; the sleep widens the same
+    // round trip so the cancellation lands inside it.
+    let cancelled = sqlx_core::rt::timeout(
+        Duration::from_millis(300),
+        pool.begin_with(AssertSqlSafe("BEGIN; SELECT pg_sleep(2);".to_string())),
+    )
+    .await;
+    assert!(cancelled.is_err(), "the begin should not have completed");
+
+    // Outlast the sleep: the queued `ROLLBACK` is only flushed once the abandoned statement
+    // has answered and the connection is on its way back to the pool.
+    sqlx_core::rt::sleep(Duration::from_millis(3500)).await;
+
+    let mut conn = new::<Postgres>().await?;
+    let state: Option<String> =
+        sqlx::query_scalar("SELECT state FROM pg_stat_activity WHERE pid = $1")
+            .bind(pid)
+            .fetch_optional(&mut conn)
+            .await?;
+
+    assert_eq!(
+        state.as_deref(),
+        Some("idle"),
+        "connection was returned to the pool still inside a transaction"
+    );
+
+    // and the pooled connection is still usable
+    let one: i32 = sqlx::query_scalar("SELECT 1").fetch_one(&pool).await?;
+    assert_eq!(one, 1);
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #4393.

### The problem

`PgTransactionManager::begin` raises `transaction_depth` only *after* the `BEGIN` round trip:

```rust
let rollback = Rollback::new(conn);
rollback.conn.queue_simple_query(statement.as_str())?;
rollback.conn.wait_until_ready().await?;      // <-- cancellation here
if !rollback.conn.in_transaction() { return Err(Error::BeginFailed); }
rollback.conn.inner.transaction_depth += 1;   // <-- only now
```

`start_rollback` is a no-op while that depth is zero, and it is what both guards call — the `Rollback` guard added in #2819 and the `Transaction`-level one added in #3980. So a future cancelled in that window queues nothing and the session stays inside a transaction.

`Floating::return_to_pool` then validates the connection with `raw.ping()`, which for Postgres is a bare `wait_until_ready`: it drains the `ReadyForQuery` but never inspects its transaction-status byte. The connection is judged healthy and handed to the next borrower, whose statements run inside the stale transaction and hold its locks. The first error turns the session into `idle in transaction (aborted)`, after which *every* unrelated query on that connection fails with `25P02` — and it never self-heals, because the depth is still zero, so no later drop queues a rollback either. Only `max_lifetime` clears it.

In production this turned a transient database slowdown into a ~20 minute outage: one poisoned connection, reused hundreds of times a second, surfacing the same `25P02` at a dozen unrelated call sites at once.

#2054 covers this and was closed by #2057, which fixed SQLite. #3980 restructures `Transaction::begin` so a cancelled caller triggers the drop guard, but for Postgres that still funnels into the same depth-gated `start_rollback`, so it does not reach this case. Reproduced on both 0.8.6 and 0.9.0.

### The change

Claim the depth before the round trip and unwind it if the `BEGIN` did not take, so the guards have something to act on.

The queued `ROLLBACK` goes into the same write buffer as the `BEGIN`, and is flushed after it — so the statement it rolls back has always been sent first. That also holds for the savepoint case: a cancelled nested `begin` now queues `ROLLBACK TO SAVEPOINT _sqlx_savepoint_{depth}` for the savepoint it just queued, rather than the enclosing one.

### Test

`it_rolls_back_a_transaction_cancelled_during_begin` in `tests/postgres/postgres.rs`. It cancels a `begin_with("BEGIN; SELECT pg_sleep(2);")` — a plain `BEGIN` answers too quickly to cancel reliably, and the sleep widens the same round trip — then asserts the session is back to `idle` rather than `idle in transaction`.

Verified against a real server: the test fails on `main` with `left: Some("idle in transaction")`, and passes with the change. I also ran the whole `--test postgres` suite before and after: the failure set is identical apart from this test (4 pre-existing failures in my environment, from fixtures my database lacks), so nothing else changes behaviour — including `it_can_work_with_failed_transactions`, `it_can_work_with_nested_transactions` and `it_can_fail_and_recover`, which all pass.

### Known trade-off

A `BEGIN` that is rejected by the server now queues a `ROLLBACK` on a session that never entered a transaction, which Postgres answers with `WARNING: there is no transaction in progress`. That seemed clearly preferable to leaking the transaction, but if you would rather not change that path, the alternative is to track "BEGIN sent, outcome unknown" in a separate flag instead of reusing the depth.

### A cheaper fix you may prefer

Postgres reports transaction status in every `ReadyForQuery`, and it is already decoded into `PgConnection::transaction_status`. `in_transaction()` is `pub(crate)`, and the public `Connection::is_in_transaction()` returns the client-side depth — precisely the value that is wrong here. Having `return_to_pool` consult the server-reported status would catch this and any other cancellation that leaves a connection dirty, at no extra round trip. Happy to take the PR in that direction instead if you prefer it.