### PR TITLE
docs: clarify `Pool::size` and `Pool::num_idle`

### DIFF
--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -531,12 +531,14 @@ impl<DB: Database> Pool<DB> {
         self.0.close_event()
     }
 
-    /// Returns the number of connections currently active. This includes idle connections.
+    /// Returns the total number of connections owned by the pool.
+    ///
+    /// This includes idle connections and ones still being opened.
     pub fn size(&self) -> u32 {
         self.0.size()
     }
 
-    /// Returns the number of connections active and idle (not in use).
+    /// Returns the number of idle connections (not checked out).
     pub fn num_idle(&self) -> usize {
         self.0.num_idle()
     }


### PR DESCRIPTION
### Summary
`num_idle` was documented as returning connections "active and idle", but it only counts idle ones. So the docs were confusing. Drop the mention of active.

`size` was documented as "currently active. This includes idle connections" which is incomplete and sound strange (idle are not part of active, so should be `and`). `try_increment_size()` bumps the counter before the connection is established, so connections still being opened are counted too (nitty detail, but may be worth mentioning).


- Isn't related to any issue
- Isn't a breaking change (only docs)





