### PR TITLE
feat(postgres): support SASL OAUTHBEARER authentication

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -408,6 +408,41 @@ jobs:
           DATABASE_URL: postgres://postgres@localhost:5432/sqlx?sslmode=verify-ca&sslrootcert=.%2Ftests%2Fcerts%2Fca.crt&sslkey=.%2Ftests%2Fcerts%2Fkeys%2Fclient.key&sslcert=.%2Ftests%2Fcerts%2Fclient.crt
           RUSTFLAGS: -D warnings --cfg postgres="${{ matrix.postgres }}"
 
+  postgres-oauth:
+    name: Postgres OAuth
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runtime: [ async-global-executor, tokio ]
+    needs: check
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - uses: Swatinem/rust-cache@v2
+
+      # This image compiles a token validator, without which the server refuses to run an
+      # OAuth exchange at all; see tests/postgres/oauth/Dockerfile.
+      - run: |
+          docker compose -f tests/docker-compose.yml run -d -p 5432:5432 --name postgres_18_oauth postgres_18_oauth
+          docker exec postgres_18_oauth bash -c "until pg_isready; do sleep 1; done"
+
+      # The OAUTHBEARER tests are ignored by default, because the mechanism is the server's
+      # choice: one asking for a password never asks for a token.
+      - run: >
+          cargo test
+          --no-default-features
+          --test postgres-oauth
+          --features postgres,macros,runtime-${{ matrix.runtime }},tls-none
+          --
+          --include-ignored
+        env:
+          DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx
+          RUSTFLAGS: -D warnings --cfg postgres="18"
+
   postgres-isolated:
     name: Postgres Isolated
     runs-on: ubuntu-24.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,6 +450,11 @@ path = "tests/postgres/derives.rs"
 required-features = ["postgres", "macros"]
 
 [[test]]
+name = "postgres-oauth"
+path = "tests/postgres/oauth.rs"
+required-features = ["postgres", "macros"]
+
+[[test]]
 name = "postgres-error"
 path = "tests/postgres/error.rs"
 required-features = ["postgres"]

--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -26,6 +26,51 @@ pub type BoxDynError = Box<dyn StdError + 'static + Send + Sync>;
 #[error("unexpected null; try decoding as an `Option`")]
 pub struct UnexpectedNullError;
 
+/// A challenge from a server that requires OAuth 2.0 authentication, carried by
+/// [`Error::OAuth`].
+///
+/// Authentication over the SASL `OAUTHBEARER` mechanism (RFC 7628) presents a bearer token
+/// that the application obtained from an identity provider. SQLx never contacts a provider
+/// itself, so a driver that has no token to present instead asks the server which one it
+/// wants; a server that rejects a token answers the same way. Either way the reply is a JSON
+/// status document naming the issuer's discovery URI and the scope the token must carry:
+///
+/// ```json
+/// {
+///   "status": "invalid_token",
+///   "openid-configuration": "https://issuer.example.com/.well-known/openid-configuration",
+///   "scope": "openid postgres"
+/// }
+/// ```
+///
+/// The document is handed over unparsed, because acting on it means running an OAuth flow
+/// that only the application can run. The connection that produced it is spent: a token
+/// obtained this way is presented by dialing again with the token set on the connect
+/// options. For PostgreSQL that is `PgConnectOptions::oauth_token`, whose documentation
+/// works the sequence through.
+#[derive(Debug, Clone)]
+pub struct OAuthChallenge {
+    document: String,
+}
+
+impl OAuthChallenge {
+    /// The server's status document, verbatim.
+    ///
+    /// This is JSON as described by [RFC 7628 §3.2.2][rfc], although a driver does not
+    /// parse it and so cannot promise it is well-formed.
+    ///
+    /// [rfc]: https://datatracker.ietf.org/doc/html/rfc7628#section-3.2.2
+    pub fn document(&self) -> &str {
+        &self.document
+    }
+}
+
+impl Display for OAuthChallenge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.document)
+    }
+}
+
 /// Represents all the ways a method can fail within SQLx.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -51,6 +96,17 @@ pub enum Error {
     /// Error occurred while attempting to establish a TLS connection.
     #[error("error occurred while attempting to establish a TLS connection: {0}")]
     Tls(#[source] BoxDynError),
+
+    /// The server requires OAuth 2.0 authentication and did not accept the token, if any,
+    /// that the connection presented.
+    ///
+    /// The payload is the server's challenge, which names the issuer to obtain a token from.
+    /// See [`OAuthChallenge`] for what to do with it.
+    #[error(
+        "OAuth 2.0 authentication failed; the server's challenge names the token it \
+             requires: {0}"
+    )]
+    OAuth(OAuthChallenge),
 
     /// Unexpected or invalid data encountered while communicating with the database.
     ///
@@ -164,6 +220,14 @@ impl Error {
     #[inline]
     pub fn config(err: impl StdError + Send + Sync + 'static) -> Self {
         Error::Configuration(err.into())
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn oauth(document: impl Into<String>) -> Self {
+        Error::OAuth(OAuthChallenge {
+            document: document.into(),
+        })
     }
 
     pub(crate) fn tls(err: impl Into<Box<dyn StdError + Send + Sync + 'static>>) -> Self {
@@ -350,4 +414,32 @@ macro_rules! err_protocol {
             )
         )
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn an_oauth_error_carries_the_challenge_both_ways() {
+        const DOCUMENT: &str = r#"{ "status": "invalid_token", "scope": "openid" }"#;
+
+        let error = Error::oauth(DOCUMENT);
+
+        // Programmatically, for an application running the OAuth flow...
+        let Error::OAuth(challenge) = &error else {
+            panic!("expected an OAuth error, got: {error:?}")
+        };
+        assert_eq!(challenge.document(), DOCUMENT);
+
+        // ...and in the message, for whoever is reading the log.
+        let message = error.to_string();
+
+        assert!(
+            message.starts_with("OAuth 2.0 authentication failed"),
+            "{message}"
+        );
+        assert!(message.ends_with(DOCUMENT), "{message}");
+        assert!(!message.contains('\n'), "{message}");
+    }
 }

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -27,6 +27,7 @@ pub use self::stream::PgStream;
 mod describe;
 mod establish;
 mod executor;
+mod oauth;
 mod resolve;
 mod sasl;
 mod stream;

--- a/sqlx-postgres/src/connection/oauth.rs
+++ b/sqlx-postgres/src/connection/oauth.rs
@@ -1,0 +1,172 @@
+use crate::connection::stream::PgStream;
+use crate::error::Error;
+use crate::message::{OAuthBearerResponse, SaslInitialResponse, SaslResponse};
+use crate::options::PgOAuthToken;
+
+/// The only SASL mechanism PostgreSQL's `oauth` HBA method advertises.
+///
+/// OAUTHBEARER defines no channel binding, so there is no `-PLUS` variant to negotiate.
+pub(crate) const MECHANISM: &str = "OAUTHBEARER";
+
+/// RFC 7628 key/value separator (`kvsep`).
+const KVSEP: &str = "\x01";
+
+/// RFC 5801 gs2-header. OAUTHBEARER has no channel binding and PostgreSQL rejects the `p`
+/// specifier outright, so this is always `n` (client does not support channel binding)
+/// followed by an empty authzid.
+const GS2_HEADER: &str = "n,,";
+
+const BEARER_SCHEME: &str = "Bearer ";
+
+/// Authenticate with a bearer token over SASL `OAUTHBEARER`.
+///
+/// This is the "token-first" flow: the token travels in the SASL initial client response, so a
+/// successful authentication costs no extra round trip. SQLx never contacts the identity
+/// provider, so the discovery flow of RFC 7628 §3.2.2 is not implemented; if the server rejects
+/// the token, the exchange is closed out and the server's error is returned.
+pub(crate) async fn authenticate(stream: &mut PgStream, token: &PgOAuthToken) -> Result<(), Error> {
+    let token = token.fetch().await?;
+    let response = initial_client_response(&token)?;
+
+    stream
+        .send(SaslInitialResponse {
+            mechanism: MECHANISM,
+            response: &response,
+        })
+        .await?;
+
+    match stream.recv_expect::<OAuthBearerResponse>().await? {
+        // The server validated the token. It sends no mechanism-specific final data, so
+        // `AuthenticationOk` arrives directly and the exchange is over.
+        OAuthBearerResponse::Ok => Ok(()),
+
+        OAuthBearerResponse::Failure(document) => {
+            // RFC 7628 §3.2.3: the only response the server will accept now is a single
+            // kvsep. Sending it lets the server report the failure as a normal
+            // `ErrorResponse` instead of leaving the exchange hanging.
+            stream.send(SaslResponse(KVSEP)).await?;
+
+            // `PgStream::recv` turns `ErrorResponse` into `Err`, which is the expected
+            // outcome here and carries the server's own diagnostic.
+            stream.recv().await?;
+
+            // Reached only if the server said something else entirely.
+            Err(err_protocol!(
+                "OAUTHBEARER authentication failed; server returned: {}",
+                String::from_utf8_lossy(&document)
+            ))
+        }
+    }
+}
+
+/// Build the initial client response: `n,,^Aauth=Bearer <token>^A^A`.
+fn initial_client_response(token: &str) -> Result<String, Error> {
+    validate_token(token)?;
+
+    Ok(format!(
+        "{GS2_HEADER}{KVSEP}auth={BEARER_SCHEME}{token}{KVSEP}{KVSEP}"
+    ))
+}
+
+/// Check the token against the `b64token` grammar of RFC 6750 §2.1, which is what the server
+/// itself enforces.
+///
+/// This is not merely a nicety. The grammar excludes the kvsep byte, whitespace and NUL, so a
+/// token that passes cannot forge additional key/value pairs or truncate the message. Checking
+/// it here turns a corrupt token into a clear local error instead of a protocol violation from
+/// the server.
+///
+/// The token value is never included in the error.
+fn validate_token(token: &str) -> Result<(), Error> {
+    // Tokens may end with any number of base64 padding characters.
+    let unpadded = token.trim_end_matches('=');
+
+    if unpadded.is_empty() {
+        return Err(Error::Configuration(
+            "OAuth bearer token is empty".to_string().into(),
+        ));
+    }
+
+    if !unpadded.bytes().all(is_b64token_byte) {
+        return Err(Error::Configuration(
+            "OAuth bearer token contains characters that are not allowed by the `b64token` \
+             grammar of RFC 6750; the token value is omitted from this error"
+                .to_string()
+                .into(),
+        ));
+    }
+
+    Ok(())
+}
+
+const fn is_b64token_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'+' | b'/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::initial_client_response;
+
+    #[test]
+    fn initial_client_response_is_token_first() {
+        // The token travels in the initial response, so no challenge is needed first.
+        assert_eq!(
+            initial_client_response("abc123").unwrap(),
+            "n,,\x01auth=Bearer abc123\x01\x01"
+        );
+    }
+
+    #[test]
+    fn initial_client_response_declares_no_channel_binding() {
+        // PostgreSQL rejects the `p` specifier for OAUTHBEARER outright.
+        let response = initial_client_response("abc123").unwrap();
+
+        assert!(response.starts_with("n,,"));
+        assert!(!response.starts_with('p'));
+    }
+
+    #[test]
+    fn padded_token_is_accepted() {
+        assert_eq!(
+            initial_client_response("dG9rZW4=").unwrap(),
+            "n,,\x01auth=Bearer dG9rZW4=\x01\x01"
+        );
+    }
+
+    #[test]
+    fn b64token_alphabet_is_accepted() {
+        initial_client_response("aZ09-._~+/").unwrap();
+    }
+
+    // The rejection cases go through `initial_client_response` rather than calling the
+    // check directly, so that dropping the check from the call site fails a test.
+
+    #[test]
+    fn token_may_not_forge_a_key_value_pair() {
+        // Without this check the kvsep would let a token append its own kvpairs.
+        initial_client_response("abc\x01host=evil").unwrap_err();
+    }
+
+    #[test]
+    fn token_may_not_contain_nul_or_whitespace() {
+        // The server compares the message length against `strlen`, so a NUL is fatal.
+        initial_client_response("abc\0def").unwrap_err();
+        initial_client_response("abc def").unwrap_err();
+        initial_client_response("abc\ndef").unwrap_err();
+    }
+
+    #[test]
+    fn empty_token_is_rejected() {
+        initial_client_response("").unwrap_err();
+        initial_client_response("==").unwrap_err();
+    }
+
+    #[test]
+    fn an_error_never_contains_the_token() {
+        const TOKEN: &str = "sensitive\x01value";
+
+        let error = initial_client_response(TOKEN).unwrap_err().to_string();
+
+        assert!(!error.contains("sensitive"));
+    }
+}

--- a/sqlx-postgres/src/connection/oauth.rs
+++ b/sqlx-postgres/src/connection/oauth.rs
@@ -1,7 +1,6 @@
 use crate::connection::stream::PgStream;
 use crate::error::Error;
 use crate::message::{OAuthBearerResponse, SaslInitialResponse, SaslResponse};
-use crate::options::PgOAuthToken;
 
 /// The only SASL mechanism PostgreSQL's `oauth` HBA method advertises.
 ///
@@ -18,15 +17,22 @@ const GS2_HEADER: &str = "n,,";
 
 const BEARER_SCHEME: &str = "Bearer ";
 
-/// Authenticate with a bearer token over SASL `OAUTHBEARER`.
+/// Authenticate over SASL `OAUTHBEARER`, presenting `token` if there is one.
 ///
-/// This is the "token-first" flow: the token travels in the SASL initial client response, so a
-/// successful authentication costs no extra round trip. SQLx never contacts the identity
-/// provider, so the discovery flow of RFC 7628 §3.2.2 is not implemented; if the server rejects
-/// the token, the exchange is closed out and the server's error is returned.
-pub(crate) async fn authenticate(stream: &mut PgStream, token: &PgOAuthToken) -> Result<(), Error> {
-    let token = token.fetch().await?;
-    let response = initial_client_response(&token)?;
+/// With a token this is the "token-first" flow: the token travels in the SASL initial client
+/// response, so a successful authentication costs no extra round trip.
+///
+/// Without one the exchange is still worth making, because it is how the caller finds out
+/// which token to get: an empty `auth` value asks the server for its OAuth parameters, and it
+/// answers with the status document that [`Error::OAuth`] carries back out. That exchange
+/// cannot succeed by design, and neither can the one where the server rejects a token, so in
+/// both cases the caller obtains a token and dials again. SQLx never contacts an identity
+/// provider itself.
+pub(crate) async fn authenticate(stream: &mut PgStream, token: Option<&str>) -> Result<(), Error> {
+    let response = match token {
+        Some(token) => initial_client_response(token)?,
+        None => discovery_client_response(),
+    };
 
     stream
         .send(SaslInitialResponse {
@@ -46,15 +52,28 @@ pub(crate) async fn authenticate(stream: &mut PgStream, token: &PgOAuthToken) ->
             // `ErrorResponse` instead of leaving the exchange hanging.
             stream.send(SaslResponse(KVSEP)).await?;
 
-            // `PgStream::recv` turns `ErrorResponse` into `Err`, which is the expected
-            // outcome here and carries the server's own diagnostic.
-            stream.recv().await?;
+            match stream.recv().await {
+                // The expected outcome, and the reason the document is what we return: the
+                // server's own error says only that authentication failed. It names neither
+                // the issuer nor the scope, so there is nothing in it for a caller that
+                // needs to go and get a token.
+                Err(Error::Database(_)) => {}
 
-            // Reached only if the server said something else entirely.
-            Err(err_protocol!(
-                "OAUTHBEARER authentication failed; server returned: {}",
-                String::from_utf8_lossy(&document)
-            ))
+                // Anything else went wrong on the way, and is not about the token.
+                Err(error) => return Err(error),
+
+                // The server has no other move here; if it made one, we no longer know what
+                // state the connection is in.
+                Ok(message) => {
+                    return Err(err_protocol!(
+                        "expected an error to close out the failed OAUTHBEARER exchange, \
+                         received {:?}",
+                        message.format
+                    ));
+                }
+            }
+
+            Err(Error::oauth(String::from_utf8_lossy(&document)))
         }
     }
 }
@@ -66,6 +85,15 @@ fn initial_client_response(token: &str) -> Result<String, Error> {
     Ok(format!(
         "{GS2_HEADER}{KVSEP}auth={BEARER_SCHEME}{token}{KVSEP}{KVSEP}"
     ))
+}
+
+/// Build a request for the server's OAuth parameters: `n,,^Aauth=^A^A`.
+///
+/// A completely empty `auth` value is how RFC 7628 §4.3 asks a server which issuer and scope
+/// a token needs; PostgreSQL answers it with the same status document it returns for a
+/// rejected token, and then fails the exchange.
+fn discovery_client_response() -> String {
+    format!("{GS2_HEADER}{KVSEP}auth={KVSEP}{KVSEP}")
 }
 
 /// Check the token against the `b64token` grammar of RFC 6750 §2.1, which is what the server
@@ -105,7 +133,7 @@ const fn is_b64token_byte(byte: u8) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::initial_client_response;
+    use super::{discovery_client_response, initial_client_response};
 
     #[test]
     fn initial_client_response_is_token_first() {
@@ -123,6 +151,13 @@ mod tests {
 
         assert!(response.starts_with("n,,"));
         assert!(!response.starts_with('p'));
+    }
+
+    #[test]
+    fn discovery_response_carries_an_empty_auth_value() {
+        // Not `auth=Bearer `: the scheme is left out entirely, which is what the server
+        // reads as a request for its OAuth parameters rather than as a malformed token.
+        assert_eq!(discovery_client_response(), "n,,\x01auth=\x01\x01");
     }
 
     #[test]
@@ -157,6 +192,8 @@ mod tests {
 
     #[test]
     fn empty_token_is_rejected() {
+        // An empty token must not be turned into a discovery request by accident: the
+        // caller asked to authenticate with a token, so this is a configuration error.
         initial_client_response("").unwrap_err();
         initial_client_response("==").unwrap_err();
     }

--- a/sqlx-postgres/src/connection/sasl.rs
+++ b/sqlx-postgres/src/connection/sasl.rs
@@ -1,3 +1,4 @@
+use crate::connection::oauth;
 use crate::connection::stream::PgStream;
 use crate::error::Error;
 use crate::message::{Authentication, AuthenticationSasl, SaslInitialResponse, SaslResponse};
@@ -24,6 +25,7 @@ pub(crate) async fn authenticate(
 ) -> Result<(), Error> {
     let mut has_sasl = false;
     let mut has_sasl_plus = false;
+    let mut has_oauth = false;
     let mut unknown = Vec::new();
 
     for mechanism in data.mechanisms() {
@@ -36,9 +38,27 @@ pub(crate) async fn authenticate(
                 has_sasl_plus = true;
             }
 
+            oauth::MECHANISM => {
+                has_oauth = true;
+            }
+
             _ => {
                 unknown.push(mechanism.to_owned());
             }
+        }
+    }
+
+    // PostgreSQL's `oauth` HBA method (added in 18) advertises OAUTHBEARER and nothing else.
+    if has_oauth {
+        if let Some(token) = &options.oauth_token {
+            return oauth::authenticate(stream, token).await;
+        }
+
+        if !has_sasl && !has_sasl_plus {
+            return Err(err_protocol!(
+                "server requested OAUTHBEARER authentication, but no OAuth token is \
+                 configured; see `PgConnectOptions::oauth_token_provider`"
+            ));
         }
     }
 
@@ -74,8 +94,8 @@ pub(crate) async fn authenticate(
 
     stream
         .send(SaslInitialResponse {
+            mechanism: "SCRAM-SHA-256",
             response: &client_first_message,
-            plus: false,
         })
         .await?;
 

--- a/sqlx-postgres/src/connection/sasl.rs
+++ b/sqlx-postgres/src/connection/sasl.rs
@@ -2,6 +2,7 @@ use crate::connection::oauth;
 use crate::connection::stream::PgStream;
 use crate::error::Error;
 use crate::message::{Authentication, AuthenticationSasl, SaslInitialResponse, SaslResponse};
+use crate::options::PgOAuthToken;
 use crate::rt;
 use crate::PgConnectOptions;
 use hmac::{Hmac, Mac};
@@ -49,17 +50,14 @@ pub(crate) async fn authenticate(
     }
 
     // PostgreSQL's `oauth` HBA method (added in 18) advertises OAUTHBEARER and nothing else.
-    if has_oauth {
-        if let Some(token) = &options.oauth_token {
-            return oauth::authenticate(stream, token).await;
-        }
+    // The exchange is worth making even with no token to present, because it is how the
+    // caller learns which token the server wants; see `oauth::authenticate`. SCRAM is
+    // preferred where the server offers it as well and there is no token, since a password
+    // may still get the connection in.
+    if has_oauth && (options.oauth_token.is_some() || !(has_sasl || has_sasl_plus)) {
+        let token = options.oauth_token.as_ref().map(PgOAuthToken::expose);
 
-        if !has_sasl && !has_sasl_plus {
-            return Err(err_protocol!(
-                "server requested OAUTHBEARER authentication, but no OAuth token is \
-                 configured; see `PgConnectOptions::oauth_token_provider`"
-            ));
-        }
+        return oauth::authenticate(stream, token).await;
     }
 
     if !has_sasl_plus && !has_sasl {

--- a/sqlx-postgres/src/lib.rs
+++ b/sqlx-postgres/src/lib.rs
@@ -56,7 +56,7 @@ pub use database::Postgres;
 pub use error::{PgDatabaseError, PgErrorPosition};
 pub use listener::{PgListener, PgNotification};
 pub use message::PgSeverity;
-pub use options::{PgConnectOptions, PgSslMode};
+pub use options::{PgConnectOptions, PgOAuthToken, PgSslMode};
 pub use query_result::PgQueryResult;
 pub use row::PgRow;
 pub use statement::PgStatement;

--- a/sqlx-postgres/src/lib.rs
+++ b/sqlx-postgres/src/lib.rs
@@ -56,7 +56,7 @@ pub use database::Postgres;
 pub use error::{PgDatabaseError, PgErrorPosition};
 pub use listener::{PgListener, PgNotification};
 pub use message::PgSeverity;
-pub use options::{PgConnectOptions, PgOAuthToken, PgSslMode};
+pub use options::{PgConnectOptions, PgSslMode};
 pub use query_result::PgQueryResult;
 pub use row::PgRow;
 pub use statement::PgStatement;

--- a/sqlx-postgres/src/message/authentication.rs
+++ b/sqlx-postgres/src/message/authentication.rs
@@ -87,6 +87,40 @@ impl BackendMessage for Authentication {
     }
 }
 
+/// The server's reply to an `OAUTHBEARER` initial client response.
+///
+/// The OAUTHBEARER exchange does not reuse [`AuthenticationSaslContinue`], whose body is a set
+/// of SCRAM attributes: on failure the server sends a JSON error document instead, and it must
+/// be read verbatim.
+#[derive(Debug)]
+pub enum OAuthBearerResponse {
+    /// The token was accepted. OAUTHBEARER carries no server signature, so the server sends no
+    /// SASL final message and `AuthenticationOk` arrives directly.
+    Ok,
+
+    /// The token was rejected. The body is the server's JSON status document, which names the
+    /// issuer and the required scope.
+    Failure(Bytes),
+}
+
+impl BackendMessage for OAuthBearerResponse {
+    const FORMAT: BackendMessageFormat = BackendMessageFormat::Authentication;
+
+    fn decode_body(mut buf: Bytes) -> Result<Self, Error> {
+        Ok(match buf.get_u32() {
+            0 => OAuthBearerResponse::Ok,
+            11 => OAuthBearerResponse::Failure(buf),
+
+            ty => {
+                return Err(err_protocol!(
+                    "unexpected authentication message {} during OAUTHBEARER exchange",
+                    ty
+                ));
+            }
+        })
+    }
+}
+
 /// Body of [Authentication::Md5Password].
 #[derive(Debug)]
 pub struct AuthenticationMd5Password {

--- a/sqlx-postgres/src/message/mod.rs
+++ b/sqlx-postgres/src/message/mod.rs
@@ -30,7 +30,7 @@ mod startup;
 mod sync;
 mod terminate;
 
-pub use authentication::{Authentication, AuthenticationSasl};
+pub use authentication::{Authentication, AuthenticationSasl, OAuthBearerResponse};
 pub use backend_key_data::BackendKeyData;
 pub use bind::Bind;
 pub use close::Close;

--- a/sqlx-postgres/src/message/sasl.rs
+++ b/sqlx-postgres/src/message/sasl.rs
@@ -4,19 +4,9 @@ use sqlx_core::Error;
 use std::num::Saturating;
 
 pub struct SaslInitialResponse<'a> {
+    /// The name of the SASL mechanism the client selected.
+    pub mechanism: &'a str,
     pub response: &'a str,
-    pub plus: bool,
-}
-
-impl SaslInitialResponse<'_> {
-    #[inline(always)]
-    fn selected_mechanism(&self) -> &'static str {
-        if self.plus {
-            "SCRAM-SHA-256-PLUS"
-        } else {
-            "SCRAM-SHA-256"
-        }
-    }
 }
 
 impl FrontendMessage for SaslInitialResponse<'_> {
@@ -26,7 +16,7 @@ impl FrontendMessage for SaslInitialResponse<'_> {
     fn body_size_hint(&self) -> Saturating<usize> {
         let mut size = Saturating(0);
 
-        size += self.selected_mechanism().len();
+        size += self.mechanism.len();
         size += 1; // NUL terminator
 
         size += 4; // response_len
@@ -37,7 +27,7 @@ impl FrontendMessage for SaslInitialResponse<'_> {
 
     fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), Error> {
         // name of the SASL authentication mechanism that the client selected
-        buf.put_str_nul(self.selected_mechanism());
+        buf.put_str_nul(self.mechanism);
 
         let response_len = i32::try_from(self.response.len()).map_err(|_| {
             err_protocol!(

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -1,15 +1,19 @@
 use std::borrow::Cow;
 use std::env::var;
 use std::fmt::{self, Display, Write};
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
+pub use oauth::PgOAuthToken;
+use sqlx_core::error::BoxDynError;
 use sqlx_core::net::tls::TlsConnector;
 pub use ssl_mode::PgSslMode;
 
 use crate::{connection::LogSettings, net::tls::CertificateInput};
 
 mod connect;
+mod oauth;
 mod parse;
 mod pgpass;
 mod ssl_mode;
@@ -29,6 +33,7 @@ pub struct PgConnectOptions {
     pub(crate) log_settings: LogSettings,
     pub(crate) extra_float_digits: Option<Cow<'static, str>>,
     pub(crate) options: Option<String>,
+    pub(crate) oauth_token: Option<PgOAuthToken>,
 }
 
 impl Default for PgConnectOptions {
@@ -108,6 +113,7 @@ impl PgConnectOptions {
             extra_float_digits: Some("2".into()),
             log_settings: Default::default(),
             options: var("PGOPTIONS").ok(),
+            oauth_token: None,
         }
     }
 
@@ -121,6 +127,62 @@ impl PgConnectOptions {
             );
         }
 
+        self
+    }
+
+    /// Authenticate with a fixed OAuth 2.0 bearer token, for PostgreSQL's `oauth`
+    /// authentication method.
+    ///
+    /// Prefer [`oauth_token_provider`][Self::oauth_token_provider] where the token can expire:
+    /// a token set here is used for every connection attempt, including reconnections made by a
+    /// pool long after the token was minted.
+    ///
+    /// The token is used only when the server requests SASL `OAUTHBEARER`; it is never sent to a
+    /// server asking for a password.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_postgres::PgConnectOptions;
+    /// # fn f(token: String) -> PgConnectOptions {
+    /// PgConnectOptions::new().oauth_token(token)
+    /// # }
+    /// ```
+    pub fn oauth_token(mut self, token: impl Into<String>) -> Self {
+        self.oauth_token = Some(PgOAuthToken::new(token));
+        self
+    }
+
+    /// Obtain an OAuth 2.0 bearer token once per connection attempt, for PostgreSQL's `oauth`
+    /// authentication method.
+    ///
+    /// SQLx does not talk to an identity provider. `provider` is called immediately before the
+    /// SASL exchange and should return a currently valid token; how it is acquired, cached and
+    /// refreshed is the application's choice.
+    ///
+    /// The token is used only when the server requests SASL `OAUTHBEARER`; it is never sent to a
+    /// server asking for a password.
+    ///
+    /// Note that there is deliberately no connection-string equivalent of this option: a URL
+    /// ends up in shell history, in `ps` output and in logs, which is no place for a bearer
+    /// token.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new().oauth_token_provider(|| async {
+    ///     // Called for each connection attempt, so an expired token can be refreshed.
+    ///     let token = std::env::var("EXAMPLE_OAUTH_TOKEN")?;
+    ///     Ok(token)
+    /// });
+    /// ```
+    pub fn oauth_token_provider<F, Fut>(mut self, provider: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<String, BoxDynError>> + Send + 'static,
+    {
+        self.oauth_token = Some(PgOAuthToken::from_provider(provider));
         self
     }
 

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -1,12 +1,10 @@
 use std::borrow::Cow;
 use std::env::var;
 use std::fmt::{self, Display, Write};
-use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
-pub use oauth::PgOAuthToken;
-use sqlx_core::error::BoxDynError;
+pub(crate) use oauth::PgOAuthToken;
 use sqlx_core::net::tls::TlsConnector;
 pub use ssl_mode::PgSslMode;
 
@@ -130,59 +128,66 @@ impl PgConnectOptions {
         self
     }
 
-    /// Authenticate with a fixed OAuth 2.0 bearer token, for PostgreSQL's `oauth`
-    /// authentication method.
+    /// Authenticate with an OAuth 2.0 bearer token, for PostgreSQL's `oauth` authentication
+    /// method (added in PostgreSQL 18).
     ///
-    /// Prefer [`oauth_token_provider`][Self::oauth_token_provider] where the token can expire:
-    /// a token set here is used for every connection attempt, including reconnections made by a
-    /// pool long after the token was minted.
+    /// The token is presented over SASL `OAUTHBEARER` (RFC 7628), and only when the server
+    /// asks for it: it is never sent to a server that wants a password.
     ///
-    /// The token is used only when the server requests SASL `OAUTHBEARER`; it is never sent to a
-    /// server asking for a password.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use sqlx_postgres::PgConnectOptions;
-    /// # fn f(token: String) -> PgConnectOptions {
-    /// PgConnectOptions::new().oauth_token(token)
-    /// # }
-    /// ```
-    pub fn oauth_token(mut self, token: impl Into<String>) -> Self {
-        self.oauth_token = Some(PgOAuthToken::new(token));
-        self
-    }
-
-    /// Obtain an OAuth 2.0 bearer token once per connection attempt, for PostgreSQL's `oauth`
-    /// authentication method.
-    ///
-    /// SQLx does not talk to an identity provider. `provider` is called immediately before the
-    /// SASL exchange and should return a currently valid token; how it is acquired, cached and
-    /// refreshed is the application's choice.
-    ///
-    /// The token is used only when the server requests SASL `OAUTHBEARER`; it is never sent to a
-    /// server asking for a password.
+    /// SQLx does not talk to an identity provider, so obtaining a token is the
+    /// application's job. A server that requires OAuth will name the issuer to get one from
+    /// if it is asked, which is what a connection with no token set does; see the example
+    /// below and [`OAuthChallenge`].
     ///
     /// Note that there is deliberately no connection-string equivalent of this option: a URL
     /// ends up in shell history, in `ps` output and in logs, which is no place for a bearer
     /// token.
     ///
+    /// # A token expires
+    ///
+    /// The token set here is presented by every connection made with these options,
+    /// including reconnections made by a pool long after the token was minted. Nothing
+    /// refreshes it, and a connection made with an expired token fails with
+    /// [`Error::OAuth`]. An application that holds a pool open for longer than its tokens
+    /// live has to mint a new token and build the pool with new options.
+    ///
     /// # Example
     ///
-    /// ```rust
-    /// # use sqlx_postgres::PgConnectOptions;
-    /// let options = PgConnectOptions::new().oauth_token_provider(|| async {
-    ///     // Called for each connection attempt, so an expired token can be refreshed.
-    ///     let token = std::env::var("EXAMPLE_OAUTH_TOKEN")?;
-    ///     Ok(token)
-    /// });
+    /// The bearer token is the whole of the exchange, so a connection either has an accepted
+    /// token or it has failed; there is no way to negotiate one part-way through. Obtaining a
+    /// token therefore means letting a connection fail, running the OAuth flow, and dialing
+    /// again:
+    ///
+    /// ```rust,no_run
+    /// # use sqlx_core::connection::Connection;
+    /// # use sqlx_core::error::{Error, OAuthChallenge};
+    /// # use sqlx_postgres::{PgConnectOptions, PgConnection};
+    /// # async fn mint_token(_challenge: &OAuthChallenge) -> sqlx_core::Result<String> {
+    /// #     unimplemented!("run an OAuth 2.0 flow against the issuer named in the challenge")
+    /// # }
+    /// # async fn f() -> sqlx_core::Result<PgConnection> {
+    /// let options = PgConnectOptions::new();
+    ///
+    /// // With no token set, the driver asks the server which one it wants. That connection
+    /// // cannot succeed; the answer comes back as an error.
+    /// let options = match PgConnection::connect_with(&options).await {
+    ///     Err(Error::OAuth(challenge)) => options.oauth_token(mint_token(&challenge).await?),
+    ///
+    ///     // The server may not want OAuth at all, in which case this already connected.
+    ///     result => return result,
+    /// };
+    ///
+    /// PgConnection::connect_with(&options).await
+    /// # }
     /// ```
-    pub fn oauth_token_provider<F, Fut>(mut self, provider: F) -> Self
-    where
-        F: Fn() -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<String, BoxDynError>> + Send + 'static,
-    {
-        self.oauth_token = Some(PgOAuthToken::from_provider(provider));
+    ///
+    /// An application that knows the issuer up front does not need the first connection: it
+    /// can mint a token and set it here directly.
+    ///
+    /// [`OAuthChallenge`]: sqlx_core::error::OAuthChallenge
+    /// [`Error::OAuth`]: sqlx_core::error::Error::OAuth
+    pub fn oauth_token(mut self, token: impl Into<String>) -> Self {
+        self.oauth_token = Some(PgOAuthToken::new(token));
         self
     }
 

--- a/sqlx-postgres/src/options/oauth.rs
+++ b/sqlx-postgres/src/options/oauth.rs
@@ -1,0 +1,93 @@
+use std::fmt::{self, Debug, Formatter};
+use std::future::Future;
+use std::sync::Arc;
+
+use futures_core::future::BoxFuture;
+use sqlx_core::error::BoxDynError;
+
+use crate::error::Error;
+
+type Provider = dyn Fn() -> BoxFuture<'static, Result<String, BoxDynError>> + Send + Sync;
+
+/// A source of OAuth 2.0 bearer tokens for PostgreSQL's `oauth` authentication method.
+///
+/// PostgreSQL 18 added the `oauth` HBA method, which authenticates a connection with an
+/// OAuth 2.0 bearer token over the SASL `OAUTHBEARER` mechanism (RFC 7628) instead of a
+/// password.
+///
+/// SQLx does not talk to an identity provider: obtaining a token is the application's job.
+/// This type wraps whatever the application already uses to get one.
+///
+/// Because tokens expire, the token is requested once per connection attempt rather than
+/// stored, so a pool that reconnects hours later presents a fresh token. Use
+/// [`PgConnectOptions::oauth_token_provider`] for that. A single token that outlives the
+/// connections made with it can be set with [`PgConnectOptions::oauth_token`].
+///
+/// [`PgConnectOptions::oauth_token_provider`]: crate::PgConnectOptions::oauth_token_provider
+/// [`PgConnectOptions::oauth_token`]: crate::PgConnectOptions::oauth_token
+#[derive(Clone)]
+pub struct PgOAuthToken {
+    provider: Arc<Provider>,
+}
+
+impl PgOAuthToken {
+    /// Use a single, fixed token for every connection attempt.
+    pub fn new(token: impl Into<String>) -> Self {
+        let token = token.into();
+
+        Self::from_provider(move || {
+            let token = token.clone();
+            async move { Ok(token) }
+        })
+    }
+
+    /// Call `provider` once per connection attempt to obtain a token.
+    pub fn from_provider<F, Fut>(provider: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<String, BoxDynError>> + Send + 'static,
+    {
+        Self {
+            provider: Arc::new(move || Box::pin(provider())),
+        }
+    }
+
+    pub(crate) async fn fetch(&self) -> Result<String, Error> {
+        (self.provider)().await.map_err(Error::Configuration)
+    }
+}
+
+/// Deliberately opaque: `PgConnectOptions` derives `Debug`, and a bearer token is a
+/// credential that must not reach a log, a panic message or an error.
+impl Debug for PgOAuthToken {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("PgOAuthToken(..)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::PgConnectOptions;
+
+    #[test]
+    fn debug_does_not_leak_the_token() {
+        // `PgConnectOptions` derives `Debug`, so the token must be opaque at every depth
+        // rather than merely absent from a hand-written summary.
+        const TOKEN: &str = "super-secret-bearer-token";
+
+        let options = PgConnectOptions::new_without_pgpass().oauth_token(TOKEN);
+
+        assert!(!format!("{:?}", options).contains(TOKEN));
+        assert!(!format!("{:#?}", options).contains(TOKEN));
+    }
+
+    #[test]
+    fn debug_does_not_leak_a_token_captured_by_a_provider() {
+        const TOKEN: &str = "super-secret-bearer-token";
+
+        let options = PgConnectOptions::new_without_pgpass()
+            .oauth_token_provider(|| async { Ok(TOKEN.to_string()) });
+
+        assert!(!format!("{:#?}", options).contains(TOKEN));
+    }
+}

--- a/sqlx-postgres/src/options/oauth.rs
+++ b/sqlx-postgres/src/options/oauth.rs
@@ -1,59 +1,21 @@
 use std::fmt::{self, Debug, Formatter};
-use std::future::Future;
-use std::sync::Arc;
 
-use futures_core::future::BoxFuture;
-use sqlx_core::error::BoxDynError;
-
-use crate::error::Error;
-
-type Provider = dyn Fn() -> BoxFuture<'static, Result<String, BoxDynError>> + Send + Sync;
-
-/// A source of OAuth 2.0 bearer tokens for PostgreSQL's `oauth` authentication method.
+/// An OAuth 2.0 bearer token, for PostgreSQL's `oauth` authentication method.
 ///
-/// PostgreSQL 18 added the `oauth` HBA method, which authenticates a connection with an
-/// OAuth 2.0 bearer token over the SASL `OAUTHBEARER` mechanism (RFC 7628) instead of a
-/// password.
+/// This exists to keep the token out of the `Debug` output of [`PgConnectOptions`], which is
+/// derived; see the `Debug` implementation below.
 ///
-/// SQLx does not talk to an identity provider: obtaining a token is the application's job.
-/// This type wraps whatever the application already uses to get one.
-///
-/// Because tokens expire, the token is requested once per connection attempt rather than
-/// stored, so a pool that reconnects hours later presents a fresh token. Use
-/// [`PgConnectOptions::oauth_token_provider`] for that. A single token that outlives the
-/// connections made with it can be set with [`PgConnectOptions::oauth_token`].
-///
-/// [`PgConnectOptions::oauth_token_provider`]: crate::PgConnectOptions::oauth_token_provider
-/// [`PgConnectOptions::oauth_token`]: crate::PgConnectOptions::oauth_token
+/// [`PgConnectOptions`]: crate::PgConnectOptions
 #[derive(Clone)]
-pub struct PgOAuthToken {
-    provider: Arc<Provider>,
-}
+pub(crate) struct PgOAuthToken(String);
 
 impl PgOAuthToken {
-    /// Use a single, fixed token for every connection attempt.
-    pub fn new(token: impl Into<String>) -> Self {
-        let token = token.into();
-
-        Self::from_provider(move || {
-            let token = token.clone();
-            async move { Ok(token) }
-        })
+    pub(crate) fn new(token: impl Into<String>) -> Self {
+        Self(token.into())
     }
 
-    /// Call `provider` once per connection attempt to obtain a token.
-    pub fn from_provider<F, Fut>(provider: F) -> Self
-    where
-        F: Fn() -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<String, BoxDynError>> + Send + 'static,
-    {
-        Self {
-            provider: Arc::new(move || Box::pin(provider())),
-        }
-    }
-
-    pub(crate) async fn fetch(&self) -> Result<String, Error> {
-        (self.provider)().await.map_err(Error::Configuration)
+    pub(crate) fn expose(&self) -> &str {
+        &self.0
     }
 }
 
@@ -78,16 +40,6 @@ mod tests {
         let options = PgConnectOptions::new_without_pgpass().oauth_token(TOKEN);
 
         assert!(!format!("{:?}", options).contains(TOKEN));
-        assert!(!format!("{:#?}", options).contains(TOKEN));
-    }
-
-    #[test]
-    fn debug_does_not_leak_a_token_captured_by_a_provider() {
-        const TOKEN: &str = "super-secret-bearer-token";
-
-        let options = PgConnectOptions::new_without_pgpass()
-            .oauth_token_provider(|| async { Ok(TOKEN.to_string()) });
-
         assert!(!format!("{:#?}", options).contains(TOKEN));
     }
 }

--- a/tests/.dockerignore
+++ b/tests/.dockerignore
@@ -4,4 +4,5 @@
 !mysql/my.cnf
 !mssql/*.sh
 !postgres/pg_hba.conf
+!postgres/oauth/*
 !*/*.sql

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -204,6 +204,24 @@ services:
     # https://www.postgresql.org/support/versioning/
     #
 
+    # The `oauth` HBA method was added in PostgreSQL 18, and needs a validator module that
+    # this image builds; see postgres/oauth/Dockerfile. Only the OAUTHBEARER tests use it,
+    # and they are ignored by default: see tests/postgres/oauth.rs.
+    postgres_18_oauth:
+        build:
+            context: .
+            dockerfile: postgres/oauth/Dockerfile
+            args:
+                VERSION: 18
+        ports:
+            - 5432
+        environment:
+            POSTGRES_DB: sqlx
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: password
+        command: >
+            -c hba_file=/var/lib/postgresql/pg_hba.conf -c oauth_validator_libraries=sqlx_oauth_validator
+
     postgres_17:
         build:
             context: .

--- a/tests/postgres/oauth.rs
+++ b/tests/postgres/oauth.rs
@@ -1,0 +1,151 @@
+//! PostgreSQL's `oauth` authentication method: SASL OAUTHBEARER, RFC 7628.
+//!
+//! Every test here is `#[ignore]`d, because none of them can run against a server that
+//! authenticates with a password: the mechanism is chosen by the server's `pg_hba.conf`, and
+//! a server asking for SCRAM never asks for a token. What they need is the
+//! `postgres_18_oauth` service in `tests/docker-compose.yml`, which is a PostgreSQL 18 with
+//! the `oauth` method and a validator module that accepts [`TOKEN`]:
+//!
+//! ```text
+//! python3 tests/x.py -t postgres_18_oauth
+//! ```
+//!
+//! or, against an already-running one:
+//!
+//! ```text
+//! cargo test --features postgres,macros --test postgres-oauth -- --include-ignored
+//! ```
+
+use std::str::FromStr;
+
+use sqlx::postgres::{PgConnectOptions, PgConnection};
+use sqlx::{Connection, Error};
+
+/// The token `tests/postgres/oauth/sqlx_oauth_validator.c` accepts.
+const TOKEN: &str = "sqlx-test-token";
+
+/// The issuer and scope `tests/postgres/oauth/pg_hba.conf` names, which the server reports
+/// in the challenge it returns for a connection it will not authenticate.
+const ISSUER: &str = "https://issuer.example.com";
+const SCOPE: &str = "openid sqlx";
+
+fn options() -> anyhow::Result<PgConnectOptions> {
+    sqlx_test::setup_if_needed();
+
+    Ok(PgConnectOptions::from_str(&std::env::var("DATABASE_URL")?)?)
+}
+
+/// The challenge is the only part of an OAuth failure a caller can act on, so every test
+/// that expects one goes through here.
+fn expect_challenge(error: Error) -> String {
+    match error {
+        Error::OAuth(challenge) => challenge.document().to_owned(),
+        other => panic!("expected an OAuth challenge, got: {other:?}"),
+    }
+}
+
+#[sqlx_macros::test]
+#[ignore = "needs a server using the `oauth` HBA method; see the module docs"]
+async fn an_accepted_token_authenticates_the_connection() -> anyhow::Result<()> {
+    let options = options()?;
+    let mut conn = PgConnection::connect_with(&options.clone().oauth_token(TOKEN)).await?;
+
+    // The bearer token got the connection in, and the password in `DATABASE_URL` played no
+    // part: the server asked for OAUTHBEARER, which carries no password.
+    let user: String = sqlx::query_scalar("select current_user")
+        .fetch_one(&mut conn)
+        .await?;
+
+    assert_eq!(user, options.get_username());
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+#[ignore = "needs a server using the `oauth` HBA method; see the module docs"]
+async fn a_connection_without_a_token_is_told_which_one_to_get() -> anyhow::Result<()> {
+    // Not a configuration error: the driver has no token, so it asks the server which one it
+    // wants. That exchange cannot succeed, and the answer arrives as the error.
+    let error = PgConnection::connect_with(&options()?).await.unwrap_err();
+    let document = expect_challenge(error);
+
+    // Everything needed to go and get a token: where to ask, and what to ask for.
+    assert!(
+        document.contains(&format!("{ISSUER}/.well-known/openid-configuration")),
+        "challenge does not name the issuer's discovery URI: {document}"
+    );
+    assert!(
+        document.contains(SCOPE),
+        "challenge does not name the required scope: {document}"
+    );
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+#[ignore = "needs a server using the `oauth` HBA method; see the module docs"]
+async fn a_rejected_token_is_reported_as_a_challenge_too() -> anyhow::Result<()> {
+    // Syntactically a fine bearer token; the validator just doesn't know it. The server
+    // answers as it does for a connection with no token at all, so an application whose
+    // token expired learns where to get a fresh one.
+    let options = options()?.oauth_token("not-the-token-the-server-accepts");
+
+    let error = PgConnection::connect_with(&options).await.unwrap_err();
+    let document = expect_challenge(error);
+
+    assert!(
+        document.contains("invalid_token"),
+        "challenge does not report the token as invalid: {document}"
+    );
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+#[ignore = "needs a server using the `oauth` HBA method; see the module docs"]
+async fn a_token_that_could_forge_a_message_never_reaches_the_server() -> anyhow::Result<()> {
+    // The kvsep byte in this token would let the rest of it become key/value pairs of the
+    // client's message. The driver checks the token against the RFC 6750 `b64token` grammar
+    // before it goes on the wire, so this is a local error rather than a protocol one, and
+    // the token stays out of it.
+    let options = options()?.oauth_token("token\u{1}host=elsewhere");
+
+    match PgConnection::connect_with(&options).await.unwrap_err() {
+        Error::Configuration(error) => {
+            assert!(
+                !error.to_string().contains("host=elsewhere"),
+                "the error quoted the token: {error}"
+            );
+        }
+        other => panic!("expected a configuration error, got: {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+#[ignore = "needs a server using the `oauth` HBA method; see the module docs"]
+async fn a_challenge_is_answered_by_dialing_again() -> anyhow::Result<()> {
+    // The sequence `PgConnectOptions::oauth_token` documents, end to end. The failed
+    // connection is spent: OAUTHBEARER has no way to present a second token on it.
+    let options = options()?;
+
+    let options = match PgConnection::connect_with(&options).await {
+        Err(Error::OAuth(challenge)) => {
+            // Standing in for an OAuth flow against the issuer the challenge names.
+            assert!(challenge.document().contains(ISSUER));
+
+            options.oauth_token(TOKEN)
+        }
+        Ok(_) => panic!("connected without a token; is this server using the `oauth` method?"),
+        Err(other) => return Err(other.into()),
+    };
+
+    let mut conn = PgConnection::connect_with(&options).await?;
+
+    let one: i32 = sqlx::query_scalar("select 1").fetch_one(&mut conn).await?;
+
+    assert_eq!(1, one);
+
+    Ok(())
+}

--- a/tests/postgres/oauth/Dockerfile
+++ b/tests/postgres/oauth/Dockerfile
@@ -1,0 +1,33 @@
+# PostgreSQL with the `oauth` HBA method configured, for the SASL OAUTHBEARER tests.
+#
+# The server hands token validation to a module it loads at authentication time and ships no
+# default one, so the image builds the validator in `sqlx_oauth_validator.c` first. The
+# compiler is left behind in the build stage.
+ARG VERSION=18
+
+FROM postgres:${VERSION} AS build
+ARG VERSION
+
+# `postgresql-server-dev-*` comes from the same PGDG repository this image is built from, so
+# the module is compiled against exactly the server that will load it. The rest are headers
+# that `libpq/oauth.h` reaches through `libpq-be.h`, which describes a server built with
+# GSSAPI, OpenSSL and LDAP support.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        "postgresql-server-dev-${VERSION}" \
+        libkrb5-dev \
+        libldap2-dev \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY postgres/oauth/Makefile postgres/oauth/sqlx_oauth_validator.c /build/
+RUN make -C /build install
+
+FROM postgres:${VERSION}
+ARG VERSION
+
+COPY --from=build \
+    "/usr/lib/postgresql/${VERSION}/lib/sqlx_oauth_validator.so" \
+    "/usr/lib/postgresql/${VERSION}/lib/"
+COPY postgres/oauth/pg_hba.conf /var/lib/postgresql/pg_hba.conf

--- a/tests/postgres/oauth/Makefile
+++ b/tests/postgres/oauth/Makefile
@@ -1,0 +1,6 @@
+# Built with PGXS inside tests/postgres/oauth/Dockerfile, which supplies pg_config.
+MODULES = sqlx_oauth_validator
+
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)

--- a/tests/postgres/oauth/pg_hba.conf
+++ b/tests/postgres/oauth/pg_hba.conf
@@ -1,0 +1,9 @@
+# The entrypoint runs initdb and the init scripts over the local socket before any client
+# connects, and cannot present a bearer token for that.
+local all all           trust
+
+# `issuer` and `scope` are what the server puts in the challenge it returns to a client that
+# has no token to present, or whose token it rejects. Nothing here has to be reachable: the
+# tests only check that the challenge names them, since obtaining a token from an issuer is
+# the application's job and not the driver's.
+host  all all all       oauth issuer="https://issuer.example.com" scope="openid sqlx"

--- a/tests/postgres/oauth/sqlx_oauth_validator.c
+++ b/tests/postgres/oauth/sqlx_oauth_validator.c
@@ -1,0 +1,53 @@
+/*
+ * The smallest possible OAuth token validator, for testing PostgreSQL's `oauth`
+ * authentication method (SASL OAUTHBEARER) against SQLx.
+ *
+ * PostgreSQL 18 ships no built-in validator and refuses to run an OAuth exchange without
+ * one, because deciding whether a bearer token is good is the identity provider's business
+ * and not the server's. A real validator checks a signature or calls an introspection
+ * endpoint; this one compares the token against a constant, which is all a driver test
+ * needs to tell an accepted token from a rejected one.
+ *
+ * See tests/postgres/oauth/Dockerfile.
+ */
+
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "libpq/oauth.h"
+
+PG_MODULE_MAGIC;
+
+/* The only token this server accepts; `tests/postgres/oauth.rs` presents it. */
+#define VALID_TOKEN "sqlx-test-token"
+
+static bool validate_token(const ValidatorModuleState *state, const char *token,
+						   const char *role, ValidatorModuleResult *result);
+
+static const OAuthValidatorCallbacks validator_callbacks = {
+	PG_OAUTH_VALIDATOR_MAGIC,
+
+	.validate_cb = validate_token
+};
+
+const OAuthValidatorCallbacks *
+_PG_oauth_validator_module_init(void)
+{
+	return &validator_callbacks;
+}
+
+static bool
+validate_token(const ValidatorModuleState *state, const char *token,
+			   const char *role, ValidatorModuleResult *result)
+{
+	result->authorized = (strcmp(token, VALID_TOKEN) == 0);
+
+	/*
+	 * The authenticated identity is the role from the startup packet, so that an accepted
+	 * token logs in as whoever asked for it and pg_hba.conf needs no user map.
+	 */
+	result->authn_id = pstrdup(role);
+
+	/* The token was examined; whether it passed is `result->authorized`. */
+	return true;
+}

--- a/tests/x.py
+++ b/tests/x.py
@@ -287,6 +287,19 @@ for runtime in RUNTIMES:
                     tag=f"postgres_{version}_client_ssl_no_password_{runtime}",
                 )
 
+        ## +oauth
+        # The OAUTHBEARER tests are ignored by default: the mechanism is the server's
+        # choice, and only this service asks for a token. See tests/postgres/oauth.rs.
+        run(
+            f"cargo test --no-default-features "
+            f"--features postgres,macros,runtime-{runtime},tls-{tls} "
+            f"--test postgres-oauth -- --include-ignored",
+            comment="test postgres 18 oauth",
+            env=postgres_env("18"),
+            service="postgres_18_oauth",
+            tag=f"postgres_18_oauth_{runtime}",
+        )
+
         #
         # mysql
         #


### PR DESCRIPTION
Closes #4399.

PostgreSQL 18's `oauth` HBA method authenticates over SASL OAUTHBEARER (RFC 7628) instead of with a password. `sasl::authenticate` accepted only SCRAM-SHA-256 and SCRAM-SHA-256-PLUS, so such a server was unreachable.

## What the driver does

SQLx does not contact an identity provider: obtaining a bearer token is the application's job. A token is the whole of the exchange, so a connection either presents an accepted one or it fails — the driver's part is to present a token if it has one, and otherwise to find out which token the server wants.

- `PgConnectOptions::oauth_token(token)` presents that token in the SASL initial client response (token-first, so no extra round trip).
- With no token set, the driver sends the empty `auth` value that RFC 7628 §4.3 and libpq use to ask a server for its OAuth parameters.
- Either way, a failed exchange returns `Error::OAuth(OAuthChallenge)`. `OAuthChallenge::document()` is the server's status document verbatim, naming the issuer's discovery URI and the required scope. The application runs its flow and dials again with the token set; nothing re-dials inside `establish`.

```rust
let options = PgConnectOptions::new();

let options = match PgConnection::connect_with(&options).await {
    Err(Error::OAuth(challenge)) => options.oauth_token(mint_token(&challenge).await?),

    // The server may not want OAuth at all, in which case this already connected.
    result => return result,
};

PgConnection::connect_with(&options).await
```

A token set on the options is not refreshed, so an application whose pool outlives its tokens has to build a pool with new options; keeping a pool supplied per connection belongs to the connect callback in #3582.

## Notes

- OAUTHBEARER defines no channel binding and the server rejects the `p` specifier, so the gs2 header is always `n,,` and this does not go through the `-PLUS` machinery.
- The token is checked against the `b64token` grammar of RFC 6750 before it reaches the wire, which is what the server enforces too. The grammar excludes the kvsep byte, whitespace and NUL, so a token that passes cannot forge additional key/value pairs or truncate the message.
- The token is held in a type whose `Debug` prints nothing, because `PgConnectOptions` derives `Debug` and a bearer token is a credential. It never appears in an error either.
- No connection-string option is added: a URL ends up in shell history, in `ps` output and in logs.
- `SaslInitialResponse` now carries the mechanism name instead of a `plus` flag that was always `false`.
- No new dependencies. The status document is handed over unparsed, which also keeps JSON out of the default build.

## Tests

`tests/postgres/oauth.rs` runs against a real PostgreSQL 18: the `postgres_18_oauth` service in `tests/docker-compose.yml`, which compiles a validator module accepting one fixed token, because the server ships none and refuses to run an OAuth exchange without one.

| Case | Result |
|---|---|
| Token accepted | **connects**; `current_user` is the requested role |
| Token rejected | `Error::OAuth`; document reports `invalid_token` |
| No token configured | `Error::OAuth`; document names the issuer's `.well-known/openid-configuration` and the scope |
| Token containing a kvsep | `Error::Configuration` before anything is sent, and the error omits the token |
| Challenge answered by dialing again | **connects** |

The tests are `#[ignore]`d, because the mechanism is the server's choice and no other test service asks for a token. The new `postgres-oauth` CI job and `python3 tests/x.py -t postgres_18_oauth` run them with `--include-ignored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
