### PR TITLE
sqlx-sqlite: relax libsqlite3-sys constraint to allow 0.38.x

### DIFF
--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -56,7 +56,7 @@ _unstable-docs = [
 
 [dependencies.libsqlite3-sys]
 # See `sqlx-sqlite/src/lib.rs` for details.
-version = ">=0.30.1, <0.38.0"
+version = ">=0.30.1, <0.39.0"
 default-features = false
 features = [
     "pkg-config",


### PR DESCRIPTION
### Does your PR solve an issue?

fixes #4379 

### Is this a breaking change?

no (just like #4161)