### PR TITLE
fix(macros): only take an integer type from `repr` in the `Type` derive

### DIFF
--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -127,8 +127,28 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
             let list: Punctuated<Meta, Token![,]> =
                 attr.parse_args_with(<Punctuated<Meta, Token![,]>>::parse_terminated)?;
 
-            if let Some(path) = list.iter().find_map(|f| f.require_path_only().ok()) {
-                try_set!(repr, path.get_ident().unwrap().clone(), list);
+            // only an integer type is a usable repr; `C`, `transparent` etc. are not
+            if let Some(ident) = list
+                .iter()
+                .filter_map(|f| f.require_path_only().ok()?.get_ident())
+                .find(|ident| {
+                    matches!(
+                        ident.to_string().as_str(),
+                        "i8" | "i16"
+                            | "i32"
+                            | "i64"
+                            | "i128"
+                            | "isize"
+                            | "u8"
+                            | "u16"
+                            | "u32"
+                            | "u64"
+                            | "u128"
+                            | "usize"
+                    )
+                })
+            {
+                try_set!(repr, ident.clone(), list);
             }
         }
     }

--- a/tests/sqlite/derives.rs
+++ b/tests/sqlite/derives.rs
@@ -13,6 +13,19 @@ test_type!(origin_enum<Origin>(Sqlite,
     "2" == Origin::Bar,
 ));
 
+// A `repr` without an integer type does not make a weak enum
+#[derive(Debug, PartialEq, sqlx::Type)]
+#[repr(C)]
+enum ReprC {
+    Foo,
+    Bar,
+}
+
+test_type!(repr_c_enum<ReprC>(Sqlite,
+    "'Foo'" == ReprC::Foo,
+    "'Bar'" == ReprC::Bar,
+));
+
 #[derive(PartialEq, Eq, Debug, sqlx::Type)]
 #[sqlx(transparent)]
 struct TransparentTuple(i64);
@@ -31,4 +44,14 @@ test_type!(transparent_tuple<TransparentTuple>(Sqlite,
 test_type!(transparent_named<TransparentNamed>(Sqlite,
     "0" == TransparentNamed { field: 0 },
     "23523" == TransparentNamed { field: 23523 },
+));
+
+#[derive(PartialEq, Eq, Debug, sqlx::Type)]
+#[sqlx(transparent)]
+#[repr(transparent)]
+struct TransparentRepr(i64);
+
+test_type!(transparent_repr<TransparentRepr>(Sqlite,
+    "0" == TransparentRepr(0),
+    "23523" == TransparentRepr(23523)
 ));


### PR DESCRIPTION
Fixes #4366.

`#[derive(sqlx::Type)]` reads the enum's `#[repr(...)]` to find the integer type of a weak enum. It took the first plain identifier in the list, so `#[repr(C)]` produced `MyEnum::Variant as C` and bounds like `C: Encode<'q, DB>`, which do not compile.

The derive now only accepts an integer type from `repr`: `i8` to `i128`, `u8` to `u128`, `isize`, and `usize`. Markers such as `C`, `transparent`, and `packed` are ignored. An enum with only `#[repr(C)]` is therefore a strong enum, mapped by variant name, the same as an enum without any `repr`. For an enum without fields that is the only form `repr(C)` can take, because Rust rejects `repr(C)` combined with an integer repr on such enums.

A side effect is that a struct with a non-integer `repr`, for example `#[repr(transparent)]` on a `#[sqlx(transparent)]` newtype, no longer fails with "unexpected #[repr(..)]". That check only makes sense for an integer `repr`.

Added two cases to `tests/sqlite/derives.rs`: a `#[repr(C)]` enum round-trips as text, and a `#[repr(transparent)]` transparent struct round-trips as an integer. Ran with:

```
DATABASE_URL=sqlite://$PWD/tests/sqlite/sqlite.db cargo test --no-default-features --features sqlite,macros,runtime-tokio --test sqlite-derives
```
