### PR TITLE
fix(postgres): return UnexpectedEof when server closes connection at SSLRequest

### DIFF
--- a/sqlx-postgres/src/connection/tls.rs
+++ b/sqlx-postgres/src/connection/tls.rs
@@ -1,3 +1,5 @@
+use std::io;
+
 use crate::error::Error;
 use crate::net::tls::{self, TlsConfig};
 use crate::net::{Socket, SocketIntoBox, WithSocket};
@@ -88,7 +90,10 @@ async fn request_upgrade(
 
     let mut response = [0u8];
 
-    socket.read(&mut &mut response[..]).await?;
+    let n = socket.read(&mut &mut response[..]).await?;
+    if n == 0 {
+        return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into());
+    }
 
     match response[0] {
         b'S' => {
@@ -105,5 +110,135 @@ async fn request_upgrade(
             "unexpected response from SSLRequest: 0x{:02x}",
             other
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx_core::io::ReadBuf;
+    use std::io;
+    use std::pin::pin;
+    use std::task::{Context, Poll, Waker};
+
+    struct MockSocket {
+        read_byte: Option<u8>,
+    }
+
+    impl Socket for MockSocket {
+        fn try_read(&mut self, buf: &mut dyn ReadBuf) -> io::Result<usize> {
+            match self.read_byte {
+                Some(b) => {
+                    buf.put_slice(&[b]);
+                    Ok(1)
+                }
+                None => Ok(0), // EOF
+            }
+        }
+
+        fn try_write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn poll_read_ready(&mut self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_write_ready(&mut self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(&mut self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    /// Polls a future that is guaranteed to complete immediately on its first poll.
+    ///
+    /// This safe test runner uses `Waker::noop()` and `std::pin::pin!` without needing
+    /// a full runtime or unsafe waker implementations.
+    fn poll_immediate<F: std::future::Future>(fut: F) -> F::Output {
+        let mut fut = pin!(fut);
+        let mut cx = Context::from_waker(Waker::noop());
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(val) => val,
+            Poll::Pending => panic!("test future was pending unexpectedly"),
+        }
+    }
+
+    #[test]
+    fn test_request_upgrade_eof() {
+        poll_immediate(async {
+            let mut socket = MockSocket { read_byte: None };
+            let options = PgConnectOptions::new();
+            let err = request_upgrade(&mut socket, &options).await.unwrap_err();
+
+            match err {
+                Error::Io(io_err) => {
+                    assert_eq!(io_err.kind(), io::ErrorKind::UnexpectedEof);
+                }
+                other => panic!("expected Error::Io(UnexpectedEof), but got: {:?}", other),
+            }
+        });
+    }
+
+    #[test]
+    fn test_request_upgrade_wire_null_byte() {
+        poll_immediate(async {
+            let mut socket = MockSocket {
+                read_byte: Some(0x00),
+            };
+            let options = PgConnectOptions::new();
+            let err = request_upgrade(&mut socket, &options).await.unwrap_err();
+
+            match err {
+                Error::Protocol(msg) => {
+                    assert!(msg.contains("unexpected response from SSLRequest: 0x00"));
+                }
+                other => panic!("expected Error::Protocol, but got: {:?}", other),
+            }
+        });
+    }
+
+    #[test]
+    fn test_request_upgrade_supported() {
+        poll_immediate(async {
+            let mut socket = MockSocket {
+                read_byte: Some(b'S'),
+            };
+            let options = PgConnectOptions::new();
+            let res = request_upgrade(&mut socket, &options).await.unwrap();
+            assert!(res);
+        });
+    }
+
+    #[test]
+    fn test_request_upgrade_unsupported() {
+        poll_immediate(async {
+            let mut socket = MockSocket {
+                read_byte: Some(b'N'),
+            };
+            let options = PgConnectOptions::new();
+            let res = request_upgrade(&mut socket, &options).await.unwrap();
+            assert!(!res);
+        });
+    }
+
+    #[test]
+    fn test_request_upgrade_unexpected_byte() {
+        poll_immediate(async {
+            let mut socket = MockSocket {
+                read_byte: Some(0x42),
+            };
+            let options = PgConnectOptions::new();
+            let err = request_upgrade(&mut socket, &options).await.unwrap_err();
+
+            match err {
+                Error::Protocol(msg) => {
+                    assert!(msg.contains("unexpected response from SSLRequest: 0x42"));
+                }
+                other => panic!("expected Error::Protocol, but got: {:?}", other),
+            }
+        });
     }
 }


### PR DESCRIPTION
### Does your PR solve an issue?
fixes #4395

### Is this a breaking change?
no

### Description
When a remote server or intermediate proxy accepts the TCP socket and immediately drops or closes the connection before responding to the 8-byte `SSLRequest`, `socket.read(&mut &mut response[..])` resolves to `0` bytes (EOF).

Previously, the return count was discarded and the unwritten buffer byte `response[0]` (`0u8`) was matched against, reporting:
`Protocol("unexpected response from SSLRequest: 0x00")`
This misleadingly claimed the server sent an illegal `0x00` protocol byte when no bytes were sent.

This change inspects the read count `n`. When `n == 0`, it returns `io::Error::from(io::ErrorKind::UnexpectedEof).into()`, properly categorizing the failure as a transport I/O error (`Error::Io`).

### Regression Tests
Includes unit tests in `sqlx-postgres/src/connection/tls.rs` verifying the EOF behavior on SSLRequest (`test_request_upgrade_eof`), which fails before this fix and passes afterwards, as well as confirming `Error::Protocol` is preserved if the server transmits an actual wire `0x00` byte (`test_request_upgrade_wire_null_byte`), along with tests for `b'S'`, `b'N'`, and unexpected byte values.
